### PR TITLE
TabFM, zero-shot tabular predictions, tested honestly

### DIFF
--- a/tabfm/README.md
+++ b/tabfm/README.md
@@ -1,0 +1,42 @@
+# TabFM, tested honestly
+
+Zero-shot tabular prediction with Google's TabFM, benchmarked honestly against XGBoost and TabICL on the same data and the same split. Everything here ran end to end before it was published.
+
+From the Friday livestream. [EPISODE VIDEO LINK]
+
+Original announcement, https://research.google/blog/introducing-tabfm-a-zero-shot-foundation-model-for-tabular-data/
+
+## Setup
+
+Python 3.11 or newer is required.
+
+```bash
+python3.12 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# the default Hugging Face Xet download backend can crash mid-download,
+# plain HTTP is reliable
+export HF_HUB_DISABLE_XET=1
+```
+
+Install from the requirements file as is. It pins `tabfm` to the GitHub repo on purpose, the PyPI 1.0.0 package cannot load the published weights (its loader wants `pytorch_model.bin`, the Hugging Face repo ships `model.safetensors`).
+
+The classification checkpoint is 6.6 GB and downloads from Hugging Face on the first `load()` call. Budget disk and a few minutes.
+
+## The scripts
+
+- `demo.py` zero-shot classification in six lines, fit stashes your table as context, predict is a single forward pass. Measured here, accuracy 1.0000 on wine, model load 7.6s warm, fit plus predict 49s on CPU.
+- `race.py` the honest benchmark, TabFM vs XGBoost vs TabICL, same split, accuracy, time, and checkpoint size side by side. Each model runs in its own subprocess, XGBoost and PyTorch both bring their own OpenMP runtime on macOS and crash or deadlock inside one process.
+- `limit-test.py` proves the 10-class hard cap first hand, an 11-class fit raises `ValueError: The number of classes (11) exceeds the maximum number of classes (10) supported by the model.`
+
+## Sharp edges to know
+
+- On CPU pass `dtype=torch.float32` to `load()`. The bfloat16 default ran ~4.5x slower on CPU in testing (220s vs 49s).
+- `predict()` returns labels in an object-dtype array, cast before handing it to sklearn metrics.
+- Hard limits, 10 classes max, optimized up to 500 features, and every training row rides along as context so memory grows with your table.
+- The code is Apache 2.0 but the weights carry the TabFM Non-Commercial License v1.0, read it before building a product on them.
+- The announced BigQuery SQL integration is not shipped yet.
+
+## The result
+
+On wine, all three models tie at accuracy 1.0000. TabFM pays 55 seconds and 13.1 GB of checkpoints for it, TabICL 2.5 seconds and 0.11 GB, XGBoost 0.4 seconds. The takeaway is not that TabFM is bad, it is that a leaderboard number is not your data. Benchmark on your own table before you swap anything out.

--- a/tabfm/demo.py
+++ b/tabfm/demo.py
@@ -1,0 +1,28 @@
+import os, time
+os.environ.setdefault("HF_HUB_DISABLE_XET", "1")   # default Xet download backend can crash, plain HTTP is reliable
+import torch
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+from tabfm.src.pytorch import tabfm_v1_0_0
+from tabfm import TabFMClassifier
+
+X, y = load_wine(return_X_y=True, as_frame=True)
+print(f"dataset: wine, {X.shape[0]} rows, {X.shape[1]} features, {y.nunique()} classes")
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, random_state=42, stratify=y)
+
+t0 = time.time()
+# dtype=float32 on CPU, the bfloat16 default is ~4.5x slower there
+model = tabfm_v1_0_0.load(dtype=torch.float32)
+print(f"model load: {time.time()-t0:.1f}s")
+
+clf = TabFMClassifier(model=model)
+t1 = time.time()
+clf.fit(X_train, y_train)                # no training, stashes the table as context
+preds = clf.predict(X_test)              # single forward pass
+print(f"fit+predict: {time.time()-t1:.1f}s")
+
+# predict() returns original labels in an object-dtype array, cast before scoring
+print(f"TabFM zero-shot accuracy: {accuracy_score(y_test, preds.astype(int)):.4f}")

--- a/tabfm/limit-test.py
+++ b/tabfm/limit-test.py
@@ -1,0 +1,17 @@
+import os
+os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+import numpy as np, torch
+from tabfm.src.pytorch import tabfm_v1_0_0
+from tabfm import TabFMClassifier
+
+rng = np.random.default_rng(0)
+X = rng.normal(size=(220, 5))
+y = np.arange(220) % 11          # 11 classes, one past the documented cap
+model = tabfm_v1_0_0.load(dtype=torch.float32)
+clf = TabFMClassifier(model=model)
+try:
+    clf.fit(X, y)
+    preds = clf.predict(X[:10])
+    print("UNEXPECTED: 11 classes fit and predicted without error")
+except Exception as e:
+    print(f"CONFIRMED, 11 classes rejected: {type(e).__name__}: {str(e)[:200]}")

--- a/tabfm/race.py
+++ b/tabfm/race.py
@@ -1,0 +1,85 @@
+"""Three-way benchmark, TabFM vs XGBoost vs TabICL, same data, same split.
+
+Each model runs in its OWN subprocess. XGBoost and PyTorch each bring their
+own OpenMP runtime on macOS, and loading both in one process segfaults or
+deadlocks. Process isolation avoids the fight entirely.
+"""
+import json, os, subprocess, sys
+
+BENCH = r'''
+import json, os, sys, time
+os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+X, y = load_wine(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, random_state=42, stratify=y)
+
+name = sys.argv[1]
+t0 = time.time()
+if name == "XGBoost":
+    from xgboost import XGBClassifier
+    m = XGBClassifier(verbosity=0)
+    m.fit(X_train, y_train); preds = m.predict(X_test)
+elif name == "TabICL":
+    from tabicl import TabICLClassifier
+    m = TabICLClassifier()
+    m.fit(X_train, y_train); preds = m.predict(X_test)
+elif name == "TabFM":
+    import torch
+    from tabfm.src.pytorch import tabfm_v1_0_0
+    from tabfm import TabFMClassifier
+    model = tabfm_v1_0_0.load(dtype=torch.float32)
+    m = TabFMClassifier(model=model)
+    m.fit(X_train, y_train); preds = m.predict(X_test)
+dt = time.time() - t0
+if getattr(preds, "dtype", None) == object:
+    preds = preds.astype(int)
+print(json.dumps({"name": name, "acc": accuracy_score(y_test, preds), "sec": dt}))
+'''
+
+results = {}
+for name in ["XGBoost", "TabICL", "TabFM"]:
+    print(f"running {name} in its own process...", flush=True)
+    out = subprocess.run([sys.executable, "-c", BENCH, name],
+                         capture_output=True, text=True)
+    line = [l for l in out.stdout.strip().splitlines() if l.startswith("{")][-1]
+    r = json.loads(line)
+    results[name] = (r["acc"], r["sec"])
+    print(f'{name:8s} accuracy={r["acc"]:.4f}  fit+predict={r["sec"]:.1f}s', flush=True)
+
+import glob
+def gb(pat):
+    return sum(os.path.getsize(f) for f in glob.glob(os.path.expanduser(pat))
+               if os.path.isfile(f) and not os.path.islink(f)) / 1e9
+
+sizes = {
+    "XGBoost": 0.001,
+    "TabICL":  gb("~/.cache/huggingface/hub/models--jingang--TabICL/blobs/*"),
+    "TabFM":   gb("~/.cache/huggingface/hub/models--google--tabfm-1.0.0-pytorch/blobs/*"),
+}
+print("checkpoint sizes GB:", {k: round(v, 3) for k, v in sizes.items()}, flush=True)
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+names = list(results)
+accs  = [results[n][0] for n in names]
+times = [results[n][1] for n in names]
+szs   = [max(sizes[n], 0.001) for n in names]
+fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+for ax, vals, title, fmt in [
+    (axes[0], accs,  "Accuracy (wine, same split)", "{:.3f}"),
+    (axes[1], times, "Fit + predict seconds",       "{:.1f}s"),
+    (axes[2], szs,   "Checkpoint size GB (log)",    "{:.3g}"),
+]:
+    bars = ax.bar(names, vals, color=["#6BA68C", "#8B82D6", "#D9734E"])
+    ax.set_title(title)
+    for b, v in zip(bars, vals):
+        ax.text(b.get_x()+b.get_width()/2, b.get_height(), fmt.format(v), ha="center", va="bottom")
+axes[2].set_yscale("log")
+plt.tight_layout()
+plt.savefig("beat3-race-chart.png", dpi=150)
+print("chart saved: beat3-race-chart.png", flush=True)

--- a/tabfm/requirements.txt
+++ b/tabfm/requirements.txt
@@ -1,0 +1,8 @@
+tabfm[pytorch] @ git+https://github.com/google-research/tabfm
+torch==2.12.1
+xgboost==3.3.0
+tabicl==2.1.1
+scikit-learn==1.9.0
+matplotlib==3.11.0
+safetensors==0.8.0
+huggingface-hub==1.22.0

--- a/tabfm/skill/SKILL.md
+++ b/tabfm/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tabfm
-description: Use this skill when working with TabFM, Google's zero-shot tabular foundation model, running classification or regression on a CSV or DataFrame without training, benchmarking TabFM against XGBoost or TabICL, or debugging TabFM installation and weight loading. Covers the tabfm Python package, TabFMClassifier and TabFMRegressor, Hugging Face weight download, the PyPI loader bug and its workarounds, hard model limits, and the weight license.
+description: Use this skill when working with TabFM, Google's zero-shot tabular foundation model, running classification or regression on a CSV or DataFrame without training, benchmarking TabFM against XGBoost or TabICL, or debugging TabFM installation and weight loading. Covers the tabfm Python package, TabFMClassifier and TabFMRegressor, Hugging Face weight download, the PyPI loader bug, CPU dtype performance, hard model limits, and the weight license.
 ---
 
 # TabFM Skill
@@ -8,10 +8,10 @@ description: Use this skill when working with TabFM, Google's zero-shot tabular 
 Zero-shot prediction on tabular data with Google's TabFM, the scikit-learn compatible foundation model that reads your whole table as context and predicts in a single forward pass, no training, no tuning, no feature engineering.
 
 > [!IMPORTANT]
-> TabFM needs Python 3.11 or newer, and the install is `pip install "tabfm[pytorch]"`. The `[pytorch]` extra is required, plain `pip install tabfm` ships NO backend and imports will fail at load time.
+> Install from the GitHub repo, `pip install "tabfm[pytorch] @ git+https://github.com/google-research/tabfm"`. Python 3.11 or newer, and the `[pytorch]` extra is required, without it no backend is installed at all.
 
 > [!WARNING]
-> PyPI `tabfm` 1.0.0 cannot load the published weights out of the box. Its loader looks for `classification/pytorch_model.bin`, but the Hugging Face repo `google/tabfm-1.0.0-pytorch` ships `model.safetensors`. Two ways out. Install the package from the GitHub repo instead (`google-research/tabfm`, its loader is safetensors native and downloads only the subfolder it needs), or keep the PyPI package and convert the weights once with the snippet in Quick Start below. The conversion path is the one verified end to end here.
+> Do NOT `pip install tabfm` from PyPI. PyPI 1.0.0 is stale and cannot load the published weights, its loader looks for `classification/pytorch_model.bin` while the Hugging Face repo `google/tabfm-1.0.0-pytorch` ships `model.safetensors`, so `load()` dies with FileNotFoundError. The GitHub package loads safetensors natively and downloads only the checkpoint it needs (6.6 GB instead of the full 13.2 GB).
 
 > [!WARNING]
 > The word open has an asterisk. The GitHub code is Apache 2.0, but the model weights carry the TabFM Non-Commercial License v1.0. Do not build a commercial product on the weights without reading that license.
@@ -28,26 +28,11 @@ Verified end to end on 2026-07-07, CPU only, no GPU.
 ```bash
 # Python >= 3.11 required (3.12 verified)
 uv venv --python 3.12 .venv
-uv pip install "tabfm[pytorch]" safetensors
+uv pip install "tabfm[pytorch] @ git+https://github.com/google-research/tabfm"
 
 # the default HF Xet download backend can crash mid-download
 # (hf-xet Internal Writer Error), plain HTTP is reliable
 export HF_HUB_DISABLE_XET=1
-```
-
-> [!WARNING]
-> The full weight snapshot is 13.15 GB (classification 6.56 GB plus regression 6.59 GB) and the PyPI loader downloads all of it. Budget disk and one cold download of a few minutes. The GitHub version downloads only the subfolder it needs.
-
-One-time weight conversion for the PyPI package (skip when installing from GitHub):
-
-```python
-import os, glob, torch
-from safetensors.torch import load_file
-
-snap = glob.glob(os.path.expanduser(
-    "~/.cache/huggingface/hub/models--google--tabfm-1.0.0-pytorch/snapshots/*"))[0]
-sd = load_file(os.path.join(snap, "classification", "model.safetensors"))
-torch.save(sd, os.path.join(snap, "classification", "pytorch_model.bin"))
 ```
 
 Zero-shot classification, the whole thing:
@@ -55,6 +40,7 @@ Zero-shot classification, the whole thing:
 ```python
 import os
 os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+import torch
 from sklearn.datasets import load_wine
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
@@ -66,7 +52,7 @@ X, y = load_wine(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(
     X, y, test_size=0.3, random_state=42, stratify=y)
 
-model = tabfm_v1_0_0.load()          # pulls weights from the HF Hub on first call
+model = tabfm_v1_0_0.load(dtype=torch.float32)   # see dtype warning below
 clf = TabFMClassifier(model=model)
 clf.fit(X_train, y_train)            # no training, stashes the table as context
 preds = clf.predict(X_test)          # single forward pass
@@ -74,9 +60,12 @@ print(accuracy_score(y_test, preds.astype(int)))
 ```
 
 > [!WARNING]
+> On CPU pass `dtype=torch.float32` to `load()`. The loader defaults to bfloat16, which ran ~4.5x slower on CPU in testing (220s vs 49s for the same fit and predict). Keep the bfloat16 default on GPU.
+
+> [!WARNING]
 > `predict()` returns the original class labels in an object-dtype numpy array. sklearn metrics refuse the mix, cast first (`preds.astype(int)` for integer labels, or compare as strings).
 
-Measured on the wine dataset (178 rows, 13 features, 3 classes), model load 10.7s warm, fit plus predict 44.5s on CPU, accuracy 1.0000.
+Measured on the wine dataset (178 rows, 13 features, 3 classes), model load 7.6s warm, fit plus predict 49.2s on CPU, accuracy 1.0000.
 
 ## Hard limits
 
@@ -85,7 +74,7 @@ From the model card and the classifier defaults, confirmed against the installed
 - Classification supports at most 10 classes, a hard architectural limit.
 - Optimized for up to 500 features (`max_num_features=500` default).
 - Every training row is passed as context at inference, memory scales with your table. Thousands of rows are fine on CPU, very large tables fall over.
-- Regression uses `TabFMRegressor` with the separate regression checkpoint (another 6.59 GB).
+- Regression uses `TabFMRegressor` with the separate regression checkpoint (6.59 GB).
 
 ## Documentation Pages
 

--- a/tabfm/skill/SKILL.md
+++ b/tabfm/skill/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: tabfm
+description: Use this skill when working with TabFM, Google's zero-shot tabular foundation model, running classification or regression on a CSV or DataFrame without training, benchmarking TabFM against XGBoost or TabICL, or debugging TabFM installation and weight loading. Covers the tabfm Python package, TabFMClassifier and TabFMRegressor, Hugging Face weight download, the PyPI loader bug and its workarounds, hard model limits, and the weight license.
+---
+
+# TabFM Skill
+
+Zero-shot prediction on tabular data with Google's TabFM, the scikit-learn compatible foundation model that reads your whole table as context and predicts in a single forward pass, no training, no tuning, no feature engineering.
+
+> [!IMPORTANT]
+> TabFM needs Python 3.11 or newer, and the install is `pip install "tabfm[pytorch]"`. The `[pytorch]` extra is required, plain `pip install tabfm` ships NO backend and imports will fail at load time.
+
+> [!WARNING]
+> PyPI `tabfm` 1.0.0 cannot load the published weights out of the box. Its loader looks for `classification/pytorch_model.bin`, but the Hugging Face repo `google/tabfm-1.0.0-pytorch` ships `model.safetensors`. Two ways out. Install the package from the GitHub repo instead (`google-research/tabfm`, its loader is safetensors native and downloads only the subfolder it needs), or keep the PyPI package and convert the weights once with the snippet in Quick Start below. The conversion path is the one verified end to end here.
+
+> [!WARNING]
+> The word open has an asterisk. The GitHub code is Apache 2.0, but the model weights carry the TabFM Non-Commercial License v1.0. Do not build a commercial product on the weights without reading that license.
+
+> [!WARNING]
+> The announced BigQuery SQL integration is upcoming, not shipped. Do not plan a `SELECT` against TabFM today.
+
+---
+
+## Quick Start
+
+Verified end to end on 2026-07-07, CPU only, no GPU.
+
+```bash
+# Python >= 3.11 required (3.12 verified)
+uv venv --python 3.12 .venv
+uv pip install "tabfm[pytorch]" safetensors
+
+# the default HF Xet download backend can crash mid-download
+# (hf-xet Internal Writer Error), plain HTTP is reliable
+export HF_HUB_DISABLE_XET=1
+```
+
+> [!WARNING]
+> The full weight snapshot is 13.15 GB (classification 6.56 GB plus regression 6.59 GB) and the PyPI loader downloads all of it. Budget disk and one cold download of a few minutes. The GitHub version downloads only the subfolder it needs.
+
+One-time weight conversion for the PyPI package (skip when installing from GitHub):
+
+```python
+import os, glob, torch
+from safetensors.torch import load_file
+
+snap = glob.glob(os.path.expanduser(
+    "~/.cache/huggingface/hub/models--google--tabfm-1.0.0-pytorch/snapshots/*"))[0]
+sd = load_file(os.path.join(snap, "classification", "model.safetensors"))
+torch.save(sd, os.path.join(snap, "classification", "pytorch_model.bin"))
+```
+
+Zero-shot classification, the whole thing:
+
+```python
+import os
+os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+from tabfm.src.pytorch import tabfm_v1_0_0
+from tabfm import TabFMClassifier
+
+X, y = load_wine(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.3, random_state=42, stratify=y)
+
+model = tabfm_v1_0_0.load()          # pulls weights from the HF Hub on first call
+clf = TabFMClassifier(model=model)
+clf.fit(X_train, y_train)            # no training, stashes the table as context
+preds = clf.predict(X_test)          # single forward pass
+print(accuracy_score(y_test, preds.astype(int)))
+```
+
+> [!WARNING]
+> `predict()` returns the original class labels in an object-dtype numpy array. sklearn metrics refuse the mix, cast first (`preds.astype(int)` for integer labels, or compare as strings).
+
+Measured on the wine dataset (178 rows, 13 features, 3 classes), model load 10.7s warm, fit plus predict 44.5s on CPU, accuracy 1.0000.
+
+## Hard limits
+
+From the model card and the classifier defaults, confirmed against the installed package.
+
+- Classification supports at most 10 classes, a hard architectural limit.
+- Optimized for up to 500 features (`max_num_features=500` default).
+- Every training row is passed as context at inference, memory scales with your table. Thousands of rows are fine on CPU, very large tables fall over.
+- Regression uses `TabFMRegressor` with the separate regression checkpoint (another 6.59 GB).
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing code. These hosted pages are the source of truth for parameters, limits, and the license, do not rely solely on the examples above.
+
+- https://github.com/google-research/tabfm
+- https://huggingface.co/google/tabfm-1.0.0-pytorch
+- https://research.google/blog/introducing-tabfm-a-zero-shot-foundation-model-for-tabular-data/
+
+## From the episode
+
+Built live on the Friday stream. [EPISODE VIDEO LINK]


### PR DESCRIPTION
Everything in this PR ran end to end before publishing. CPU only, no GPU.

## What is in here

- `tabfm/demo.py` zero-shot classification in six lines. Measured, accuracy 1.0000 on wine, model load 7.6s warm, fit plus predict 49.2s on CPU.
- `tabfm/race.py` the honest benchmark, TabFM vs XGBoost vs TabICL on the same split. Result, all three tie at accuracy 1.0000, TabFM takes 55.0s and 13.1 GB of checkpoints, TabICL 2.5s and 0.11 GB, XGBoost 0.4s. Each model runs in its own subprocess, XGBoost and PyTorch both bring their own OpenMP runtime on macOS and crash or deadlock in one process.
- `tabfm/limit-test.py` first-hand proof of the 10-class hard cap, an 11-class fit raises the exact ValueError.
- `tabfm/requirements.txt` pinned to the versions that actually ran. It installs tabfm from GitHub on purpose, the PyPI 1.0.0 package cannot load the published weights (its loader wants pytorch_model.bin, the Hugging Face repo ships model.safetensors).
- `tabfm/skill/SKILL.md` the installable agent skill with the verified quick start and the sharp edges as inline callouts, license split, 10 classes and 500 features, the Xet download workaround, and the CPU dtype gotcha.
- `tabfm/README.md` setup, the scripts, and the honest result.

## Sharp edges documented

- PyPI tabfm 1.0.0 cannot load the published weights, install from GitHub
- Default HF Xet download backend can crash mid-download, HF_HUB_DISABLE_XET=1 fixes it
- The loader defaults to bfloat16 which ran ~4.5x slower on CPU, pass dtype=torch.float32
- predict() returns object-dtype labels, cast before sklearn metrics
- Code is Apache 2.0, weights are TabFM Non-Commercial License v1.0

Merging this live on the Friday stream.