### PR TITLE
Managed Agents skill, background execution and remote MCP

### DIFF
--- a/managed-agents/README.md
+++ b/managed-agents/README.md
@@ -1,0 +1,26 @@
+# Managed Agents, background execution and remote MCP
+
+Gemini API Managed Agents run server side in a Google hosted sandbox. This episode covers the July 2026 upgrades, background execution (fire a task, get an id, reconnect later), attaching remote MCP servers as tools, custom function calling, and reusing a sandbox across turns.
+
+The skill and all runnable code live in [skill/](skill/).
+
+- [skill/SKILL.md](skill/SKILL.md), the skill, current facts, quick start, gotchas inline.
+- [skill/scripts/](skill/scripts/), the three verified demos plus the REST helper.
+- [skill/requirements.txt](skill/requirements.txt), one dependency, `requests`.
+
+Install for your agent.
+
+```
+npx skills add <this-repo> --skill managed-agents
+```
+
+Run the demos. Needs Python 3.10 or newer, `client.interactions` lives in `google-genai` 2.x.
+
+```
+export GEMINI_API_KEY=your_key_here
+pip install -r skill/requirements.txt     # google-genai>=2.3.0
+cd skill/scripts
+python background_run.py          # prints an interaction id
+python reconnect.py <that-id>     # reconnects and shows the step trace
+python mcp_tool.py                # attaches the demo weather MCP server
+```

--- a/managed-agents/README.md
+++ b/managed-agents/README.md
@@ -5,7 +5,7 @@ Gemini API Managed Agents run server side in a Google hosted sandbox. This episo
 The skill and all runnable code live in [skill/](skill/).
 
 - [skill/SKILL.md](skill/SKILL.md), the skill, current facts, quick start, gotchas inline.
-- [skill/scripts/](skill/scripts/), the three verified demos plus the REST helper.
+- [skill/scripts/](skill/scripts/), the three verified demos plus the shared SDK helper they import.
 - [skill/requirements.txt](skill/requirements.txt), one dependency, `requests`.
 
 Install for your agent.

--- a/managed-agents/skill/SKILL.md
+++ b/managed-agents/skill/SKILL.md
@@ -63,7 +63,7 @@ for step in rec.steps:
 ```
 
 > [!WARNING]
-> A background interaction returns `environment_id` as `None`, even on the completed record. You cannot reopen that exact sandbox afterward. If you need the sandbox to persist across turns, run a foreground interaction (omit `background`) and chain with the `environment_id` it returns, see the next block.
+> A background interaction that creates its own sandbox returns `environment_id` as `None`, on the create response AND on the completed record, so that sandbox can never be referenced again. Passing an existing `environment_id` INTO a background create works and the files persist. The pattern, seed the sandbox with one foreground turn to get its `environment_id`, then run any number of background turns inside it, see the next block.
 
 > [!TIP]
 > To resume a dropped live stream instead of polling, `client.interactions.get(id, stream=True, last_event_id=last_seen)` replays from the last event you saw.

--- a/managed-agents/skill/SKILL.md
+++ b/managed-agents/skill/SKILL.md
@@ -101,7 +101,7 @@ The agent keeps its built in sandbox tools and also gets the remote MCP server's
 ```python
 inter = client.interactions.create(
     agent=AGENT,
-    input="What is the weather in Berlin today? Use the weather tool.",
+    input="Do I need a jacket in Berlin today? Use the weather tool.",
     environment="remote",
     tools=[{
         "type": "mcp_server",
@@ -113,7 +113,7 @@ inter = client.interactions.create(
 ```
 
 > [!WARNING]
-> A remote MCP server is a live network dependency inside your agent run. If it is slow, down, or rate limited, the interaction stalls or errors. Treat it like any other flaky upstream, set expectations and have a fallback.
+> A remote MCP server is a live network dependency inside your agent run. Observed live, a second tool call on this demo server returned `CONNECTION_CLOSED` mid interaction, the error surfaced as a `function_result` step with `agent_error` and the agent still answered from the data it already had. Treat a remote MCP server like any other flaky upstream, expect per call failures in the step trace and have a fallback.
 
 ### Custom function calling, the requires_action flow
 

--- a/managed-agents/skill/SKILL.md
+++ b/managed-agents/skill/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill when running Gemini API Managed Agents through the I
 
 # Gemini Managed Agents Skill
 
-Managed Agents run server side in a Google hosted sandbox that can write files and run code for you. The Interactions API drives them, through `client.interactions` in the `google-genai` SDK. This skill covers the four capabilities that shipped in July 2026 on top of the existing managed agents, background execution, remote MCP tools, custom functions, and credential refresh.
+Managed Agents run server side in a Google hosted sandbox that can write files and run code for you. The Interactions API drives them, through `client.interactions` in the `google-genai` SDK. July 2026 added four capabilities on top of the existing managed agents. Three are covered below with verified code, background execution, remote MCP tools, and custom function calling. The fourth, network credential refresh, is documented on the antigravity agent page linked at the bottom.
 
 > [!IMPORTANT]
 > The managed agent is `antigravity-preview-05-2026`, powered by Gemini 3.5 Flash. Pass it in the `agent` field, never `model`. Passing it as `model` returns HTTP 400, "antigravity-preview-05-2026 is not supported as a model. Use it as an agent instead." Google's own background execution doc shows `model=` here, which throws, while the antigravity agent doc and Google's Interactions API skill both correctly use `agent`. The name carries `preview` for a reason, expect it to change, do not hardcode it as permanent.
@@ -67,6 +67,9 @@ for step in rec.steps:
 
 > [!TIP]
 > To resume a dropped live stream instead of polling, `client.interactions.get(id, stream=True, last_event_id=last_seen)` replays from the last event you saw.
+
+> [!IMPORTANT]
+> The id is your ONLY handle on an interaction. A dropped connection does not kill the work, a foreground streaming run killed mid task kept working server side and was fully retrievable by `get(id)` afterward. But there is no list endpoint (GET on the interactions collection returns 404), so an interaction whose id you never captured is unrecoverable even though it completed. Persist the id the moment you receive it, and prefer `background=True`, which returns the id instantly instead of at the end of the run.
 
 ### Reuse a sandbox across turns with environment_id
 
@@ -141,7 +144,7 @@ final = client.interactions.create(
 | `code_execution_result` | `result` (str), `call_id`, `is_error`                    |
 | `model_output`          | `content` (list of text parts, each with `.text`)        |
 
-Statuses seen in prep, `in_progress`, `completed`, `requires_action`.
+Statuses observed against the live API, `in_progress`, `completed`, `requires_action`.
 
 ## Supporting files
 

--- a/managed-agents/skill/SKILL.md
+++ b/managed-agents/skill/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: managed-agents
+description: Use this skill when running Gemini API Managed Agents through the Interactions API, especially background execution (background=True, poll and reconnect by interaction id), attaching remote MCP servers as tools, custom function calling with the requires_action flow, and reusing a server side sandbox across turns with environment_id. Covers the antigravity managed agent, the client.interactions SDK surface, and the agent vs model gotcha. SDKs and tools used, google-genai Python SDK (client.interactions), Python 3.10+, Gemini API key.
+---
+
+# Gemini Managed Agents Skill
+
+Managed Agents run server side in a Google hosted sandbox that can write files and run code for you. The Interactions API drives them, through `client.interactions` in the `google-genai` SDK. This skill covers the four capabilities that shipped in July 2026 on top of the existing managed agents, background execution, remote MCP tools, custom functions, and credential refresh.
+
+> [!IMPORTANT]
+> The managed agent is `antigravity-preview-05-2026`, powered by Gemini 3.5 Flash. Pass it in the `agent` field, never `model`. Passing it as `model` returns HTTP 400, "antigravity-preview-05-2026 is not supported as a model. Use it as an agent instead." Google's own background execution doc shows `model=` here, which throws, while the antigravity agent doc and Google's Interactions API skill both correctly use `agent`. The name carries `preview` for a reason, expect it to change, do not hardcode it as permanent.
+
+> [!IMPORTANT]
+> `client.interactions` lives in `google-genai` 2.x, which requires Python 3.10 or newer. Install `pip install "google-genai>=2.3.0"`. On the Python 3.9 that ships with macOS, pip caps at 1.47.0, which does not have `client.interactions`, and the samples will `AttributeError`, that is an interpreter version issue, not a missing feature. Managed agent interactions also require `environment="remote"`.
+
+> [!WARNING]
+> Managed Agents are not new in July 2026, they already existed. The Interactions API itself went GA in June 2026, but the managed agent model is still Preview, and environment compute is not billed during preview, that will change. You still pay for tokens.
+
+---
+
+## Quick Start
+
+Set the key once, then create a client.
+
+```bash
+export GEMINI_API_KEY=your_key_here
+```
+
+```python
+import os, time
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+AGENT = "antigravity-preview-05-2026"
+```
+
+### Background execution, fire and reconnect
+
+Kick off a long task, get an id back immediately, then poll it from anywhere, no held connection.
+
+```python
+# fire and forget
+inter = client.interactions.create(
+    agent=AGENT,
+    input="Create a folder named project/ and write hello.py inside that prints hi.",
+    environment="remote",
+    background=True,
+)
+
+interaction_id = inter.id          # your claim ticket
+print(inter.status)                # in_progress, it did NOT wait for the work
+
+# later, fresh process, only the id, poll until done
+while True:
+    rec = client.interactions.get(interaction_id)
+    if rec.status != "in_progress":
+        break
+    time.sleep(2)
+
+# the completed record carries the full step trace, thought, tool call, result
+for step in rec.steps:
+    print(step.type, getattr(step, "name", ""))
+```
+
+> [!WARNING]
+> A background interaction returns `environment_id` as `None`, even on the completed record. You cannot reopen that exact sandbox afterward. If you need the sandbox to persist across turns, run a foreground interaction (omit `background`) and chain with the `environment_id` it returns, see the next block.
+
+> [!TIP]
+> To resume a dropped live stream instead of polling, `client.interactions.get(id, stream=True, last_event_id=last_seen)` replays from the last event you saw.
+
+### Reuse a sandbox across turns with environment_id
+
+A foreground interaction returns `environment_id`. Chain the next turn with both `previous_interaction_id` and `environment` to land in the same sandbox with your files intact.
+
+```python
+first = client.interactions.create(
+    agent=AGENT,
+    input="Write notes.txt containing the single line: prep works.",
+    environment="remote",
+)
+
+second = client.interactions.create(
+    agent=AGENT,
+    previous_interaction_id=first.id,
+    environment=first.environment_id,   # same sandbox, files persist
+    input="List the files and show the contents of notes.txt.",
+)
+```
+
+> [!WARNING]
+> Forget `environment` on the chained call and you get a brand new sandbox with none of your files. Both `previous_interaction_id` and `environment` are required together.
+
+### Attach a remote MCP server as a tool
+
+The agent keeps its built in sandbox tools and also gets the remote MCP server's tools in the same interaction.
+
+```python
+inter = client.interactions.create(
+    agent=AGENT,
+    input="What is the weather in Tokyo today? Use the weather tool.",
+    environment="remote",
+    tools=[{
+        "type": "mcp_server",
+        "name": "weather",                                  # lowercase alphanumeric
+        "url": "https://gemini-api-demos.uc.r.appspot.com/mcp",
+        # optional: "headers": {...}, "allowed_tools": [...]
+    }],
+)
+```
+
+> [!WARNING]
+> A remote MCP server is a live network dependency inside your agent run. If it is slow, down, or rate limited, the interaction stalls or errors. Treat it like any other flaky upstream, set expectations and have a fallback.
+
+### Custom function calling, the requires_action flow
+
+Add your own tools next to the sandbox tools. The agent pauses at `status == "requires_action"`, you run the pending `function_call` steps, then return each `function_result`.
+
+```python
+final = client.interactions.create(
+    agent=AGENT,
+    previous_interaction_id=inter.id,
+    environment=inter.environment_id,
+    input=[{
+        "type": "function_result",
+        "call_id": fc_step.id,       # id of the function_call step you executed
+        "result": your_result,
+    }],
+)
+```
+
+## Interaction record shape
+
+`create` and `get` return an `Interaction` object. `inter.steps` is a list of typed step objects, in the order the agent produced them. Which tool-step types appear depends on how the agent solved the task (it may write a file or run code).
+
+| `step.type`             | key attributes                                          |
+| ----------------------- | ------------------------------------------------------- |
+| `thought`               | `summary`                                               |
+| `function_call`         | `name`, `arguments` (dict), `id`                         |
+| `function_result`       | `result` (list of text parts), `call_id`, `is_error`     |
+| `code_execution_call`   | `arguments.code`, `arguments.language`, `id`             |
+| `code_execution_result` | `result` (str), `call_id`, `is_error`                    |
+| `model_output`          | `content` (list of text parts, each with `.text`)        |
+
+Statuses seen in prep, `in_progress`, `completed`, `requires_action`.
+
+## Supporting files
+
+- [scripts/agent.py](scripts/agent.py), tiny SDK helper, `create`, `get`, `poll`, `show_steps` (handles both file-write and code-execution step traces). Import it, the three demos below do.
+- [scripts/background_run.py](scripts/background_run.py), fire a background task and print the id. Run it, then pass the id to the next one.
+- [scripts/reconnect.py](scripts/reconnect.py), `python reconnect.py <id>`, poll by id and print the step trace the agent ran while you were disconnected.
+- [scripts/mcp_tool.py](scripts/mcp_tool.py), attach the demo weather MCP server and print what the agent called.
+- [requirements.txt](requirements.txt), the one dependency, `google-genai>=2.3.0` (Python 3.10+).
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing code. These hosted docs are the source of truth for parameters, types, and edge cases, do not rely solely on the examples above. The SDK samples need `google-genai >= 2.3.0` on Python 3.10+, and the background execution page shows `model=` where the working call needs `agent=`.
+
+- https://ai.google.dev/gemini-api/docs/background-execution
+- https://ai.google.dev/gemini-api/docs/antigravity-agent
+- https://ai.google.dev/gemini-api/docs/interactions-overview
+- https://github.com/google-gemini/gemini-skills/tree/main/skills/gemini-interactions-api
+
+## From the episode
+
+Built live on the Friday stream, video link to follow.

--- a/managed-agents/skill/SKILL.md
+++ b/managed-agents/skill/SKILL.md
@@ -42,7 +42,8 @@ Kick off a long task, get an id back immediately, then poll it from anywhere, no
 # fire and forget
 inter = client.interactions.create(
     agent=AGENT,
-    input="Create a folder named project/ and write hello.py inside that prints hi.",
+    input="Create a folder stream-tools/ and write chapters.py inside that turns "
+          "a list of video timestamps into YouTube chapter markers.",
     environment="remote",
     background=True,
 )
@@ -78,7 +79,7 @@ A foreground interaction returns `environment_id`. Chain the next turn with both
 ```python
 first = client.interactions.create(
     agent=AGENT,
-    input="Write notes.txt containing the single line: prep works.",
+    input="Write episode-notes.txt containing the single line: background agents keep working.",
     environment="remote",
 )
 
@@ -86,7 +87,7 @@ second = client.interactions.create(
     agent=AGENT,
     previous_interaction_id=first.id,
     environment=first.environment_id,   # same sandbox, files persist
-    input="List the files and show the contents of notes.txt.",
+    input="List the files and show the contents of episode-notes.txt.",
 )
 ```
 
@@ -100,7 +101,7 @@ The agent keeps its built in sandbox tools and also gets the remote MCP server's
 ```python
 inter = client.interactions.create(
     agent=AGENT,
-    input="What is the weather in Tokyo today? Use the weather tool.",
+    input="What is the weather in Berlin today? Use the weather tool.",
     environment="remote",
     tools=[{
         "type": "mcp_server",

--- a/managed-agents/skill/requirements.txt
+++ b/managed-agents/skill/requirements.txt
@@ -1,0 +1,1 @@
+google-genai>=2.3.0

--- a/managed-agents/skill/scripts/agent.py
+++ b/managed-agents/skill/scripts/agent.py
@@ -1,0 +1,62 @@
+"""Tiny helper for Gemini Interactions API managed agents, via the google-genai SDK.
+
+client.interactions lives in google-genai 2.x, which requires Python 3.10 or newer.
+Install with: pip install "google-genai>=2.3.0"
+"""
+import os
+import time
+from google import genai
+
+AGENT = "antigravity-preview-05-2026"  # preview, the name will change, do not hardcode forever
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+
+def create(**body):
+    # NOTE gotcha, the managed agent goes in "agent", NOT "model". Passing it as
+    # "model" returns 400 "use it as an agent instead".
+    body.setdefault("agent", AGENT)
+    body.setdefault("environment", "remote")
+    return client.interactions.create(**body)
+
+
+def get(interaction_id):
+    return client.interactions.get(interaction_id)
+
+
+def poll(interaction_id, every=2, cap=180):
+    """Poll a background interaction by id until it stops running."""
+    waited = 0
+    while waited < cap:
+        rec = get(interaction_id)
+        if rec.status != "in_progress":
+            return rec
+        time.sleep(every)
+        waited += every
+    raise TimeoutError(f"still in_progress after {cap}s")
+
+
+def _text(v):
+    # tool results come back as a str, model output as a list of text parts
+    if v is None:
+        return ""
+    if isinstance(v, str):
+        return v
+    return "".join(getattr(c, "text", "") for c in v)
+
+
+def show_steps(rec):
+    for s in rec.steps:
+        t = s.type
+        if t == "function_call":
+            args = getattr(s, "arguments", None) or {}
+            action = args.get("toolAction", "") if isinstance(args, dict) else ""
+            print(f"  call   {getattr(s, 'name', None) or 'tool'}  {action}")
+        elif t == "code_execution_call":
+            code = getattr(getattr(s, "arguments", None), "code", "") or ""
+            print(f"  code   {' '.join(code.split())[:80]}")
+        elif t in ("function_result", "code_execution_result"):
+            out = _text(getattr(s, "result", None)).strip()
+            if out:
+                print(f"  result {out[:80]}")
+        elif t == "model_output":
+            print(f"  say    {_text(getattr(s, 'content', None)).strip()[:200]}")

--- a/managed-agents/skill/scripts/background_run.py
+++ b/managed-agents/skill/scripts/background_run.py
@@ -1,0 +1,12 @@
+"""Beat 1, fire and forget. Kick off a real task, get an id back instantly."""
+import agent
+
+rec = agent.create(
+    input="Create a folder named project/ and write hello.py inside that prints hi.",
+    background=True,
+)
+print("id:    ", rec.id)
+print("status:", rec.status)   # in_progress, it did not wait for the work
+print()
+print("Save this id, that is your claim ticket:")
+print(rec.id)

--- a/managed-agents/skill/scripts/background_run.py
+++ b/managed-agents/skill/scripts/background_run.py
@@ -2,7 +2,8 @@
 import agent
 
 rec = agent.create(
-    input="Create a folder named project/ and write hello.py inside that prints hi.",
+    input="Create a folder stream-tools/ and write chapters.py inside that turns "
+          "a list of video timestamps into YouTube chapter markers.",
     background=True,
 )
 print("id:    ", rec.id)

--- a/managed-agents/skill/scripts/mcp_tool.py
+++ b/managed-agents/skill/scripts/mcp_tool.py
@@ -1,0 +1,17 @@
+"""Beat 3, bolt a remote MCP server onto the agent as a tool.
+
+The agent keeps its built in sandbox tools (its hands) and also gets a remote
+MCP server (a phone it can call out on). Here it uses Google's demo weather MCP.
+"""
+import agent
+
+rec = agent.create(
+    input="What is the weather in Tokyo today? Use the weather tool.",
+    tools=[{
+        "type": "mcp_server",
+        "name": "weather",   # lowercase alphanumeric
+        "url": "https://gemini-api-demos.uc.r.appspot.com/mcp",
+    }],
+)
+print("status:", rec.status)
+agent.show_steps(rec)

--- a/managed-agents/skill/scripts/mcp_tool.py
+++ b/managed-agents/skill/scripts/mcp_tool.py
@@ -6,7 +6,7 @@ MCP server (a phone it can call out on). Here it uses Google's demo weather MCP.
 import agent
 
 rec = agent.create(
-    input="What is the weather in Tokyo today? Use the weather tool.",
+    input="What is the weather in Berlin today? Use the weather tool.",
     tools=[{
         "type": "mcp_server",
         "name": "weather",   # lowercase alphanumeric

--- a/managed-agents/skill/scripts/mcp_tool.py
+++ b/managed-agents/skill/scripts/mcp_tool.py
@@ -6,7 +6,7 @@ MCP server (a phone it can call out on). Here it uses Google's demo weather MCP.
 import agent
 
 rec = agent.create(
-    input="What is the weather in Berlin today? Use the weather tool.",
+    input="Do I need a jacket in Berlin today? Use the weather tool.",
     tools=[{
         "type": "mcp_server",
         "name": "weather",   # lowercase alphanumeric

--- a/managed-agents/skill/scripts/reconnect.py
+++ b/managed-agents/skill/scripts/reconnect.py
@@ -1,0 +1,14 @@
+"""Beat 2, reconnect. Fresh process, only the id. Poll until done, show the work.
+
+Usage, pass the id printed by background_run.py:
+    python reconnect.py <interaction_id>
+"""
+import sys
+import agent
+
+interaction_id = sys.argv[1]
+print(f"reconnecting to {interaction_id} ...")
+rec = agent.poll(interaction_id)
+print("status:", rec.status)
+print("steps the agent ran while we were disconnected:")
+agent.show_steps(rec)


### PR DESCRIPTION
## What this adds

A new `managed-agents` topic with an installable agent skill and three runnable demos for the July 2026 Managed Agents additions in the Gemini API, all verified live against the Interactions API.

### Skill, `managed-agents/skill/SKILL.md`
- Background execution, fire a task with `background=True`, reconnect by id, read the full step trace
- Sandbox persistence with `environment_id`, including the seed-then-background pattern
- Remote MCP servers as tools, custom function calling via `requires_action`
- Current-facts callouts, the `agent` vs `model` field gotcha (one docs page disagrees with the API and Google's own skill), `google-genai>=2.3.0` needs Python 3.10+, background runs return a null `environment_id`, the id is the only handle on an interaction (no list endpoint)

### Demos, `managed-agents/skill/scripts/`
- `background_run.py`, fire a task, get the claim ticket instantly
- `reconnect.py`, fresh process, only the id, poll and print the trace
- `mcp_tool.py`, attach a remote MCP weather server, includes a live-observed per-call failure surfacing in the step trace

Every snippet and output ran against the live API before landing here.

Merging live on the Friday stream.