### PR TITLE
Add agent-eval-flywheel skill, how Google grades AI agents

### DIFF
--- a/agent-eval-flywheel/.gitignore
+++ b/agent-eval-flywheel/.gitignore
@@ -1,0 +1,3 @@
+.adk/
+__pycache__/
+*.pyc

--- a/agent-eval-flywheel/README.md
+++ b/agent-eval-flywheel/README.md
@@ -1,0 +1,13 @@
+# Agent Eval Flywheel
+
+How Google grades AI agents, from the Friday livestream. You pick a metric that matches what you care
+about, run the eval, read what the judge says, and refine. The payoff is a judge that scores meaning
+and explains its verdict in plain English.
+
+The installable skill and all verified code live in [skill/](skill/). Start with [skill/SKILL.md](skill/SKILL.md).
+
+Install it into your coding agent:
+
+```
+npx skills add SaschaHeyer/gen-ai-livestream/agent-eval-flywheel
+```

--- a/agent-eval-flywheel/skill/SKILL.md
+++ b/agent-eval-flywheel/skill/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: agent-eval-flywheel
+description: >
+  Use this skill to evaluate an ADK agent with Google's Agent Quality Flywheel, run an evalset,
+  choose the right metric, and read the results. Covers the ADK metric menu and which metrics run
+  locally versus which call an AI judge, how the LLM judge scores meaning rather than words, how a
+  rubric judge writes a plain-English reason for each verdict graded against trusted evidence, and
+  how to close the eval fix loop. SDKs and tools used, agents-cli, adk eval, google-adk[eval], the
+  Gemini API for the agent and the judge.
+---
+
+# Agent Eval Flywheel Skill
+
+How Google grades AI agents, and how you drive the loop. You pick a metric that matches what you care
+about, run the eval, read what the judge says, and refine. The payoff is a judge that scores an
+answer's meaning and explains its verdict in plain English, a score you can act on.
+
+> [!IMPORTANT]
+> Two skills ship this workflow. `google-agents-cli-eval` drives ADK agents through `agents-cli eval
+> run` (which wraps `adk eval`). `agent-platform-eval-flywheel` is the framework agnostic sibling for
+> the cloud Evaluation SDK. This skill covers the local ADK path, which needs nothing but the Gemini
+> API key.
+
+> [!IMPORTANT]
+> The metric menu is the whole mental model. Two metrics run LOCALLY and free, `tool_trajectory_avg_score`
+> (did it call the right tools) and `response_match_score` (does the text match a reference). The rest
+> are LLM as judge, `final_response_match_v2`, `rubric_based_final_response_quality_v1`,
+> `rubric_based_tool_use_quality_v1`, `hallucinations_v1`, and `safety_v1`. First decision every time,
+> do you care about the exact words or the meaning. Words, use a local metric. Meaning, use a judge.
+
+---
+
+## Quick Start
+
+The full eval fix loop, all verified against google-adk 2.4.0 on Python 3.12 with the Gemini API key.
+
+```bash
+# 1. Environment. The agent AND the judge both call the Gemini API.
+export GOOGLE_GENAI_USE_VERTEXAI=0
+export GOOGLE_API_KEY=YOUR_AI_STUDIO_KEY
+
+# 2. Grade with the free local metrics.
+adk eval ./episode_finder tests/eval/evalsets/episode_finder.evalset.json \
+  --config_file_path tests/eval/eval_config.json --print_detailed_results
+#   tool_trajectory_avg_score  PASSED 1.0   <- it called the right tool
+
+# 3. Add an AI judge. It scores MEANING, not words.
+adk eval ./episode_finder tests/eval/evalsets/episode_finder.evalset.json \
+  --config_file_path tests/eval/eval_config_judge.json --print_detailed_results
+#   final_response_match_v2    PASSED 1.0
+
+# 4. Close the loop. Keep tool trajectory plus the judge, rerun, all green.
+adk eval ./episode_finder tests/eval/evalsets/episode_finder.evalset.json \
+  --config_file_path tests/eval/eval_config_fixed.json --print_detailed_results
+```
+
+> [!NOTE]
+> `response_match_score` is ROUGE, it compares words. A correct answer worded differently from your
+> reference scores low (measured 0.2 to 0.35 on this agent, always under the 0.5 threshold). That is
+> not a broken agent, it is the signal to use a judge when you care about meaning, not exact wording.
+
+> [!WARNING]
+> `adk eval` needs the eval extra. A bare `pip install google-adk` gives `Error: Eval module is not
+> installed, please install via pip install "google-adk[eval]"`. Install `google-adk[eval]`.
+
+> [!WARNING]
+> The system macOS Python is 3.9, google-adk needs 3.10 or newer. Stand up a current interpreter,
+> `uv venv --python 3.12`, before installing.
+
+### The judge that explains itself
+
+The best part of the toolkit. A rubric judge grades against plain-English rules you write, and writes
+a reason for each one, against the trusted answer. `adk eval` prints scores but drops the rationale
+into a history JSON under `AGENT_DIR/.adk/eval_history/`, so `eval_report.py` surfaces it.
+
+```bash
+python eval_report.py ./episode_finder \
+  tests/eval/evalsets/episode_finder.evalset.json \
+  --config tests/eval/eval_config_rubric.json
+```
+
+Real output, the judge grading against the trusted evidence.
+
+```
+Q  Which Stage Studio episode covered background agents?
+A  Episode e02, titled "Managed Agents background and remote MCP", covered background agents.
+   rubric_based_final_response_quality_v1: PASSED score=1.0
+      why [names_episode_id] 1.0: states "Episode e02", consistent with the trusted evidence.
+      why [names_title] 1.0: includes the title "Managed Agents background and remote MCP".
+      why [no_guessing] 1.0: only the episode id and title from the find_episode tool, nothing invented.
+```
+
+> [!IMPORTANT]
+> The judge is decoupled by design. Whatever wrote the answer, your agent, an optimizer, or you, does
+> NOT grade it. A separate judge model call scores it against the reference and writes the reason.
+> Keeping the optimizer and the grader apart is the point of the flywheel.
+
+## Workflow
+
+When asked to evaluate an ADK agent, follow this loop.
+
+1. Analyze the goal. Care about MEANING, reach for an LLM judge. Care about the exact tool sequence,
+   use `tool_trajectory_avg_score`, local and free.
+2. Run `eval_report.py AGENT_DIR EVALSET --config CONFIG` so you see the judge's reasons, not just
+   red or green numbers.
+3. Read the reason, make one change, rerun. Expect several iterations on a real agent, that is normal,
+   each pass makes it better.
+
+## Dependencies and Prerequisites
+
+- Python 3.10 or newer (`uv venv --python 3.12` if the system Python is 3.9).
+- `google-adk[eval] >= 2.4.0`, install `uv pip install "google-adk[eval]"`.
+- `agents-cli` optional, for the wrapped `agents-cli eval run` command,
+  `uv tool install google-agents-cli`. Verified at 0.1.1, 1.0.0 is available.
+- A Gemini API key for both the agent and the judge, or Vertex via
+  `GOOGLE_GENAI_USE_VERTEXAI=1` and a project.
+
+> [!NOTE]
+> Automatic Loss Analysis (failure clustering) and adaptive AutoRaters that write a feedback paragraph
+> are Gemini Enterprise Agent Platform features, the cloud product, not the local `adk eval` path.
+> Locally the per rubric rationale above is the closest thing to that, and it is most of the value.
+
+## Supporting files
+
+- [scripts/eval_report.py](scripts/eval_report.py), run any agent and evalset and print the judge's
+  per rubric reasons. `python eval_report.py AGENT_DIR EVALSET --config CONFIG`.
+- [scripts/episode_finder/](scripts/episode_finder/), the tiny verified demo agent, a helper with one
+  find_episode tool.
+- [scripts/tests/eval/evalsets/episode_finder.evalset.json](scripts/tests/eval/evalsets/episode_finder.evalset.json), a two case evalset.
+- [scripts/tests/eval/eval_config.json](scripts/tests/eval/eval_config.json), local metrics only.
+- [scripts/tests/eval/eval_config_judge.json](scripts/tests/eval/eval_config_judge.json), adds the AI judge `final_response_match_v2`.
+- [scripts/tests/eval/eval_config_fixed.json](scripts/tests/eval/eval_config_fixed.json), tool trajectory plus the judge, all green.
+- [scripts/tests/eval/eval_config_rubric.json](scripts/tests/eval/eval_config_rubric.json), rubric judge with three rules, the reasons come from here.
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing eval code. These hosted docs are the source of
+truth for the metric names, config schema, and thresholds, do not rely solely on the examples above.
+
+- https://github.com/google/agents-cli
+- https://github.com/google/skills
+- https://developers.googleblog.com/driving-the-agent-quality-flywheel-from-your-coding-agent/
+
+## From the episode
+
+Video, link once it is up.

--- a/agent-eval-flywheel/skill/requirements.txt
+++ b/agent-eval-flywheel/skill/requirements.txt
@@ -1,0 +1,1 @@
+google-adk[eval]>=2.4.0

--- a/agent-eval-flywheel/skill/scripts/episode_finder/__init__.py
+++ b/agent-eval-flywheel/skill/scripts/episode_finder/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/agent-eval-flywheel/skill/scripts/episode_finder/agent.py
+++ b/agent-eval-flywheel/skill/scripts/episode_finder/agent.py
@@ -1,0 +1,48 @@
+"""A tiny Stage Studio helper agent, deliberately buggy so the eval catches it.
+
+The agent answers which livestream episode covered a given topic. It has a
+find_episode tool that holds the real answer. The instruction below is the
+BUGGY version, it lets the model answer from memory instead of calling the
+tool, so tool_trajectory_avg_score will fail. Beat 3 fixes the instruction.
+"""
+
+from google.adk.agents import Agent
+
+# The real episode catalogue. The tool is the only source of truth.
+_CATALOGUE = {
+    "tabular foundation model": {"episode": "e01", "title": "TabFM zero shot tabular"},
+    "background agents": {"episode": "e02", "title": "Managed Agents background and remote MCP"},
+    "remote mcp": {"episode": "e02", "title": "Managed Agents background and remote MCP"},
+    "agent evaluation": {"episode": "e03", "title": "Agent Quality Flywheel eval skill"},
+}
+
+
+def find_episode(topic: str) -> dict:
+    """Look up which Stage Studio episode covered a topic.
+
+    Args:
+        topic: The subject the viewer is asking about, for example
+            "background agents" or "agent evaluation".
+
+    Returns:
+        A dict with the episode id and title, or a not_found marker.
+    """
+    key = topic.strip().lower()
+    for name, record in _CATALOGUE.items():
+        if name in key or key in name:
+            return {"found": True, **record}
+    return {"found": False, "topic": topic}
+
+
+# BUGGY instruction, it invites the model to answer from memory.
+root_agent = Agent(
+    name="episode_finder",
+    model="gemini-2.5-flash",
+    description="Tells viewers which Stage Studio episode covered a topic.",
+    instruction=(
+        "You are the Stage Studio episode helper. When a viewer asks which "
+        "episode covered a topic, tell them the episode id and title. You know "
+        "the show well."
+    ),
+    tools=[find_episode],
+)

--- a/agent-eval-flywheel/skill/scripts/eval_report.py
+++ b/agent-eval-flywheel/skill/scripts/eval_report.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Run an ADK eval and surface the judge's rationale, which adk eval hides.
+
+`adk eval` prints a scores table but drops the per rubric rationale into a
+history JSON you have to dig for. This wrapper runs the eval and prints, for
+every case and metric, the score AND the judge's written reason when there is
+one. Point it at your own agent and evalset.
+
+Usage:
+    python eval_report.py AGENT_DIR EVALSET_JSON --config CONFIG_JSON
+
+Example:
+    python eval_report.py ./episode_finder \\
+        tests/eval/evalsets/episode_finder.evalset.json \\
+        --config tests/eval/eval_config_rubric.json
+
+Requires the same env any adk eval needs, for the AI Studio key path:
+    export GOOGLE_GENAI_USE_VERTEXAI=0
+    export GOOGLE_API_KEY=...
+"""
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+
+_STATUS = {1: "PASSED", 2: "FAILED", 3: "NOT_EVALUATED"}
+
+
+def _latest_history(agent_dir: str) -> str:
+    hist = glob.glob(os.path.join(agent_dir, ".adk", "eval_history", "*.json"))
+    if not hist:
+        sys.exit("No eval history written, did the eval run fail?")
+    return max(hist, key=os.path.getmtime)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Run adk eval and show the judge's why.")
+    ap.add_argument("agent_dir", help="Path to the agent package dir")
+    ap.add_argument("evalset", help="Path to the evalset JSON")
+    ap.add_argument("--config", required=True, help="Path to the eval config JSON")
+    args = ap.parse_args()
+
+    # adk eval is the real work, we only re-read its history for the rationale.
+    proc = subprocess.run(
+        ["adk", "eval", args.agent_dir, args.evalset, "--config_file_path", args.config],
+        stderr=subprocess.DEVNULL,
+    )
+
+    data = json.load(open(_latest_history(args.agent_dir)))
+    print("\n=== Eval report, scores and the judge's reasons ===")
+    for case in data["eval_case_results"]:
+        inv = case["eval_metric_result_per_invocation"][0]
+        q = inv["actual_invocation"]["user_content"]["parts"][0]["text"]
+        a = inv["actual_invocation"]["final_response"]["parts"][0]["text"]
+        print(f"\nQ  {q}\nA  {a}")
+        for m in inv["eval_metric_results"]:
+            print(f"   {m['metric_name']}: {_STATUS.get(m['eval_status'], m['eval_status'])} "
+                  f"score={m['score']} threshold={m['threshold']}")
+            for r in (m["details"].get("rubric_scores") or []):
+                print(f"      why [{r.get('rubric_id')}] {r.get('score')}: {r.get('rationale', '').strip()}")
+    sys.exit(proc.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-eval-flywheel/skill/scripts/tests/eval/eval_config.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/eval_config.json
@@ -1,0 +1,11 @@
+{
+  "criteria": {
+    "tool_trajectory_avg_score": {
+      "threshold": 1.0,
+      "match_type": "IN_ORDER"
+    },
+    "response_match_score": {
+      "threshold": 0.5
+    }
+  }
+}

--- a/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_fixed.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_fixed.json
@@ -1,0 +1,11 @@
+{
+  "criteria": {
+    "tool_trajectory_avg_score": {
+      "threshold": 1.0,
+      "match_type": "IN_ORDER"
+    },
+    "final_response_match_v2": {
+      "threshold": 0.8
+    }
+  }
+}

--- a/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_judge.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_judge.json
@@ -1,0 +1,14 @@
+{
+  "criteria": {
+    "tool_trajectory_avg_score": {
+      "threshold": 1.0,
+      "match_type": "IN_ORDER"
+    },
+    "response_match_score": {
+      "threshold": 0.5
+    },
+    "final_response_match_v2": {
+      "threshold": 0.8
+    }
+  }
+}

--- a/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_rubric.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_rubric.json
@@ -1,0 +1,12 @@
+{
+  "criteria": {
+    "rubric_based_final_response_quality_v1": {
+      "threshold": 0.8,
+      "rubrics": [
+        {"rubric_id": "names_episode_id", "rubric_content": {"text_property": "The response states the specific episode id, for example e02."}},
+        {"rubric_id": "names_title", "rubric_content": {"text_property": "The response includes the episode title."}},
+        {"rubric_id": "no_guessing", "rubric_content": {"text_property": "The response only states facts that came from the find_episode tool, it does not invent details."}}
+      ]
+    }
+  }
+}

--- a/agent-eval-flywheel/skill/scripts/tests/eval/evalsets/episode_finder.evalset.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/evalsets/episode_finder.evalset.json
@@ -1,0 +1,96 @@
+{
+  "eval_set_id": "episode_finder_evalset",
+  "name": "episode_finder_evalset",
+  "description": "Does the helper call find_episode before answering",
+  "eval_cases": [
+    {
+      "eval_id": "bg-agents",
+      "conversation": [
+        {
+          "invocation_id": "bg-agents-inv1",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Which Stage Studio episode covered background agents?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "That was episode e02."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "args": {
+                  "topic": "background agents"
+                },
+                "name": "find_episode"
+              }
+            ],
+            "tool_responses": [],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0
+        }
+      ],
+      "session_input": {
+        "app_name": "episode_finder",
+        "user_id": "viewer",
+        "state": {}
+      },
+      "creation_timestamp": 0.0,
+      "final_session_state": {}
+    },
+    {
+      "eval_id": "agent-eval",
+      "conversation": [
+        {
+          "invocation_id": "agent-eval-inv1",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Which episode covered agent evaluation?"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "That was episode e03."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "args": {
+                  "topic": "agent evaluation"
+                },
+                "name": "find_episode"
+              }
+            ],
+            "tool_responses": [],
+            "intermediate_responses": []
+          },
+          "creation_timestamp": 0.0
+        }
+      ],
+      "session_input": {
+        "app_name": "episode_finder",
+        "user_id": "viewer",
+        "state": {}
+      },
+      "creation_timestamp": 0.0,
+      "final_session_state": {}
+    }
+  ],
+  "creation_timestamp": 0.0
+}


### PR DESCRIPTION
Episode 3 skill. Teaches how Google's Agent Quality Flywheel grades an AI agent on the local ADK path, verified end to end against google-adk 2.4.0.

## What it teaches
- The metric menu, which metrics run locally and free vs which call an AI judge.
- An LLM judge (`final_response_match_v2`) that scores an answer's meaning, not its words.
- A rubric judge that grades your plain-English rules and writes a reason for each verdict, against the trusted answer.
- Closing the eval fix loop, read the reason, fix, rerun.

## What ships
- `agent-eval-flywheel/skill/SKILL.md`, the installable skill.
- `scripts/eval_report.py`, a parameterized utility that surfaces the judge's per rubric reasons that `adk eval` hides. Point it at any agent and evalset.
- `scripts/episode_finder/`, a tiny verified demo agent with one tool.
- `scripts/tests/eval/`, the evalset and four eval configs (local, judge, rubric, fixed).

## Verified
Every command ran clean against google-adk 2.4.0 on Python 3.12 with the Gemini API key. Scripts re-run green from their final location.

## Notes
- Needs `google-adk[eval]` and Python 3.10+.
- Loss clustering and paragraph feedback are cloud Agent Platform features, this path covers the local ADK eval and the rubric reasons.

Companion to Google's own skills in https://github.com/google/skills, theirs is the API surface, this carries the field notes from running it.