### PR TITLE
Add the Optimize and Iterate loop to agent-eval-flywheel

### DIFF
--- a/agent-eval-flywheel/skill/SKILL.md
+++ b/agent-eval-flywheel/skill/SKILL.md
@@ -95,6 +95,42 @@ A  Episode e02, titled "Managed Agents background and remote MCP", covered backg
 > NOT grade it. A separate judge model call scores it against the reference and writes the reason.
 > Keeping the optimizer and the grader apart is the point of the flywheel.
 
+### Optimize and iterate, the loop closing
+
+This is the payoff. The judge told you WHY a case failed, so you apply one targeted fix and rerun to
+prove it helped. Google's own framing, it proposes, you approve, human in the loop, not hands off. The
+fix is almost always an edit to the agent's instruction, not the model.
+
+Start from an agent that has no footer, graded by a rubric that requires one
+(`eval_config_footer.json`). The judge fails it and says exactly why.
+
+```
+BEFORE   rubric_based_final_response_quality_v1: FAILED score=0.5
+  why [names_episode]     1.0: names the correct episode id and title.
+  why [ends_with_footer]  0.0: does not contain the footer line "More at stagestudio.tv".
+```
+
+The fix the judge points you to is one line added to the agent's instruction.
+
+```python
+instruction=(
+    "You are the Stage Studio episode helper. When a viewer asks which "
+    "episode covered a topic, tell them the episode id and title. "
+    "End every response with the exact line: More at stagestudio.tv"   # <- the fix
+)
+```
+
+Rerun the same eval, and the loop closes.
+
+```
+AFTER    rubric_based_final_response_quality_v1: PASSED score=1.0
+  why [names_episode]     1.0: names the correct episode id and title.
+  why [ends_with_footer]  1.0: ends with the exact line "More at stagestudio.tv".
+```
+
+That is one turn of the flywheel, read the reason, apply a targeted fix, rerun, compare to the
+baseline. Repeat until the case passes, expect several turns on a real agent.
+
 ## Workflow
 
 When asked to evaluate an ADK agent, follow this loop.
@@ -131,6 +167,7 @@ When asked to evaluate an ADK agent, follow this loop.
 - [scripts/tests/eval/eval_config_judge.json](scripts/tests/eval/eval_config_judge.json), adds the AI judge `final_response_match_v2`.
 - [scripts/tests/eval/eval_config_fixed.json](scripts/tests/eval/eval_config_fixed.json), tool trajectory plus the judge, all green.
 - [scripts/tests/eval/eval_config_rubric.json](scripts/tests/eval/eval_config_rubric.json), rubric judge with three rules, the reasons come from here.
+- [scripts/tests/eval/eval_config_footer.json](scripts/tests/eval/eval_config_footer.json), the optimize and iterate demo, a footer rubric that fails until you add the footer line to the instruction.
 
 ## Documentation Pages
 

--- a/agent-eval-flywheel/skill/SKILL.md
+++ b/agent-eval-flywheel/skill/SKILL.md
@@ -16,10 +16,11 @@ about, run the eval, read what the judge says, and refine. The payoff is a judge
 answer's meaning and explains its verdict in plain English, a score you can act on.
 
 > [!IMPORTANT]
-> Two skills ship this workflow. `google-agents-cli-eval` drives ADK agents through `agents-cli eval
-> run` (which wraps `adk eval`). `agent-platform-eval-flywheel` is the framework agnostic sibling for
-> the cloud Evaluation SDK. This skill covers the local ADK path, which needs nothing but the Gemini
-> API key.
+> Two skills ship this workflow. `google-agents-cli-eval` drives ADK agents through the agents-cli
+> toolchain (in agents-cli 0.1.1 `eval run` shells out to `adk eval`, in 1.0.0 it chains
+> `eval generate` and `eval grade`). `agent-platform-eval-flywheel` is the framework agnostic sibling
+> for the cloud Evaluation SDK, published in google/skills under skills/cloud/. This skill covers the
+> local ADK path, which needs nothing but the Gemini API key.
 
 > [!IMPORTANT]
 > The metric menu is the whole mental model. Two metrics run LOCALLY and free, `tool_trajectory_avg_score`
@@ -131,6 +132,12 @@ AFTER    rubric_based_final_response_quality_v1: PASSED score=1.0
 That is one turn of the flywheel, read the reason, apply a targeted fix, rerun, compare to the
 baseline. Repeat until the case passes, expect several turns on a real agent.
 
+> [!NOTE]
+> An automated version of this turn exists. google-adk 2.4.0 ships `adk optimize`, which refines the
+> root agent instructions with the GEPA framework against a target metric, and agents-cli 1.0.0
+> exposes it as the experimental `eval optimize`. Both are confirmed from the tools' own help output,
+> not yet exercised by this skill's verified runs, treat them as experimental.
+
 ## Workflow
 
 When asked to evaluate an ADK agent, follow this loop.
@@ -146,8 +153,10 @@ When asked to evaluate an ADK agent, follow this loop.
 
 - Python 3.10 or newer (`uv venv --python 3.12` if the system Python is 3.9).
 - `google-adk[eval] >= 2.4.0`, install `uv pip install "google-adk[eval]"`.
-- `agents-cli` optional, for the wrapped `agents-cli eval run` command,
-  `uv tool install google-agents-cli`. Verified at 0.1.1, 1.0.0 is available.
+- `agents-cli` optional, `uv tool install google-agents-cli`. Verified at 0.1.1 where `eval run`
+  shells out to `adk eval`. The 1.0.0 release restructures the group, `eval run` chains
+  `eval generate` and `eval grade`, and adds experimental `eval analyze` (loss clusters, needs a
+  GCP project) and `eval optimize` (runs `adk optimize`, GEPA prompt refinement).
 - A Gemini API key for both the agent and the judge, or Vertex via
   `GOOGLE_GENAI_USE_VERTEXAI=1` and a project.
 

--- a/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_footer.json
+++ b/agent-eval-flywheel/skill/scripts/tests/eval/eval_config_footer.json
@@ -1,0 +1,11 @@
+{
+  "criteria": {
+    "rubric_based_final_response_quality_v1": {
+      "threshold": 0.8,
+      "rubrics": [
+        {"rubric_id": "names_episode", "rubric_content": {"text_property": "The response names the correct episode id and title from the find_episode tool."}},
+        {"rubric_id": "ends_with_footer", "rubric_content": {"text_property": "The response ends with the exact footer line: More at stagestudio.tv"}}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #9 (which merged the base skill). This adds the payoff that #9 was missing, the Optimize and Iterate loop, the flywheel actually closing.

## What this adds
- A real, verified before/after in `SKILL.md`. A footer rubric fails the agent (`ends_with_footer` 0.0, the judge names the missing line), a one-line instruction fix makes it pass 1.0 on rerun. Mirrors Google's own footer-mandate example.
- `scripts/tests/eval/eval_config_footer.json`, the footer rubric that drives the demo.

## Why it matters
This is the "Optimize & Iterate" stage from Google's five stages, it proposes, you approve, human in the loop. The fix edits the agent's instruction (the prompt), not the model, and a separate judge, not the thing that wrote the fix, confirms it worked.

## Verified
Runs clean against google-adk 2.4.0 on Python 3.12 with the Gemini API key. Before FAILED 0.5, after PASSED 1.0, reproducible.