### PR TITLE
Reword the decoupling callout in our own voice, attribute the rule to Google

### DIFF
--- a/agent-eval-flywheel/skill/SKILL.md
+++ b/agent-eval-flywheel/skill/SKILL.md
@@ -92,9 +92,10 @@ A  Episode e02, titled "Managed Agents background and remote MCP", covered backg
 ```
 
 > [!IMPORTANT]
-> The judge is decoupled by design. Whatever wrote the answer, your agent, an optimizer, or you, does
-> NOT grade it. A separate judge model call scores it against the reference and writes the reason.
-> Keeping the optimizer and the grader apart is the point of the flywheel.
+> The judge is decoupled by design, Google's rule. Nothing grades its own work, the agent does not
+> score its answers and the optimizer does not score its fixes. A separate judge model call does the
+> grading against the reference and writes the reason. Keeping those two roles apart is the point of
+> the flywheel.
 
 ### Optimize and iterate, the loop closing
 


### PR DESCRIPTION
Follow-up to #10, this commit was pushed after the merge and missed it.

The decoupling callout in SKILL.md reused the sentence structure from Google's blog post without marking it as their phrasing. Now the principle is attributed to Google and the wording is ours. No functional changes, one callout block reworded.