### PR TITLE
e04, cite GA-blog production proof in the notebook intro

### DIFF
--- a/alphaevolve/notebook.ipynb
+++ b/alphaevolve/notebook.ipynb
@@ -21,7 +21,7 @@
    "id": "954e897c",
    "metadata": {},
    "source": [
-    "> **What you need.** AlphaEvolve rides on a Gemini Enterprise license, any tier including a trial, and you point it at your own Gemini Enterprise app (the engine id). Without one, the cloud cells will not run for you, but every one below carries its real saved output so you can read along and see exactly what a run looks like."
+    "> **What you need.** AlphaEvolve rides on a Gemini Enterprise license, any tier including a trial, and you point it at your own Gemini Enterprise app (the engine id). Without one, the cloud cells will not run for you, but every one below carries its real saved output so you can read along and see exactly what a run looks like. My honest take, this is a developer API and really belongs on Vertex AI with pay per use, not behind an enterprise seat, but that is a packaging call, not a technical one."
    ]
   },
   {

--- a/alphaevolve/notebook.ipynb
+++ b/alphaevolve/notebook.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Give a naive function a scoring function, and let a Gemini ensemble evolve it into something better. In this notebook you run the exact circle packing demo from the episode, watch the score climb, and then change the seed yourself to see what moves.\n",
     "\n",
-    "One honest note up front. AlphaEvolve is not new, it is DeepMind research from 2025, the system famous for a faster matrix multiplication. What is new is that it went generally available on Google Cloud with an open source client library, so you can finally run it on your own code.\n",
+    "One honest note up front. AlphaEvolve is not new, it is DeepMind research from 2025, the system famous for a faster matrix multiplication. What is new is that it went generally available on Google Cloud with an open source client library, so you can finally run it on your own code. It is already in production, Google reports using it to cut Spanner write amplification by 20 percent, and early users like JetBrains and Schrodinger report real speedups. Those are their results, we produce our own below.\n",
     "\n",
     "\ud83d\udcfa Watch the build: [EPISODE VIDEO LINK]\n",
     "\n",


### PR DESCRIPTION
Follow-up to #14 (already merged). Adds one attributed sentence to the notebook intro, Google's launch-post production results (Spanner 20 percent write-amplification cut, JetBrains and Schrodinger speedups). Attributed to Google, our own executed run stays the demo result. Executed outputs unchanged.