### PR TITLE
e07 Semantic Governance: govern an ADK agent's tool calls with a plain-English policy

### DIFF
--- a/semantic-governance/demo/authz_ext.json
+++ b/semantic-governance/demo/authz_ext.json
@@ -1,0 +1,6 @@
+{
+  "service": "us-central1.sgp.internal",
+  "authority": "us-central1.sgp.internal",
+  "failOpen": false,
+  "loadBalancingScheme": "LOAD_BALANCING_SCHEME_UNSPECIFIED"
+}

--- a/semantic-governance/demo/authz_policy.json
+++ b/semantic-governance/demo/authz_policy.json
@@ -1,0 +1,17 @@
+{
+  "target": {
+    "loadBalancingScheme": "LOAD_BALANCING_SCHEME_UNSPECIFIED",
+    "resources": ["projects/sascha-playground-doit/locations/us-central1/agentGateways/merch-egress-gw"]
+  },
+  "httpRules": [{
+    "to": {"operations": [{"paths": [{"prefix": "/"}]}]},
+    "when": "!request.headers['content-type'].startsWith('application/grpc') && (request.path.endsWith(':generateContent') || request.path.endsWith(':streamGenerateContent'))"
+  }],
+  "action": "CUSTOM",
+  "policyProfile": "CONTENT_AUTHZ",
+  "customProvider": {
+    "authzExtension": {
+      "resources": ["projects/sascha-playground-doit/locations/us-central1/authzExtensions/sgp-authz-ext"]
+    }
+  }
+}

--- a/semantic-governance/demo/deploy_agent.py
+++ b/semantic-governance/demo/deploy_agent.py
@@ -1,0 +1,69 @@
+"""Deploy the ADK merch-support agent to Agent Runtime, behind the egress
+Agent Gateway, with agent identity so Semantic Governance can enforce on it.
+
+Both agent_gateway_config AND identity_type=AGENT_IDENTITY must be set at
+create time, per the routing docs. Updating an existing agent does not
+retroactively enable SGP.
+"""
+
+import vertexai
+from google.adk.agents import Agent
+from vertexai import agent_engines, types
+
+PROJ = "sascha-playground-doit"
+LOC = "us-central1"
+GW = f"projects/{PROJ}/locations/{LOC}/agentGateways/merch-egress-gw"
+BUCKET = f"gs://{PROJ}-agent-staging"
+
+
+def issue_refund(order_id: str, amount_eur: float, ship_country: str) -> dict:
+    """Issue a refund for a creator merch order.
+
+    Args:
+        order_id: the order to refund, e.g. HAM-4471
+        amount_eur: refund amount in euros
+        ship_country: destination country the order shipped to
+    """
+    return {
+        "status": "refunded",
+        "order_id": order_id,
+        "amount_eur": amount_eur,
+        "ship_country": ship_country,
+    }
+
+
+agent = Agent(
+    model="gemini-2.5-flash",
+    name="merch_support_agent",
+    instruction=(
+        "You are the support agent for a creator merch store based in Hamburg. "
+        "When a customer asks for a refund, call issue_refund with the order id, "
+        "the amount in euros, and the destination country. If a refund is blocked "
+        "by policy, explain the reason plainly."
+    ),
+    tools=[issue_refund],
+)
+
+app = agent_engines.AdkApp(agent=agent)
+client = vertexai.Client(project=PROJ, location=LOC)
+
+print("Deploying merch_support_agent to Agent Runtime (this builds a container)...")
+remote = client.agent_engines.create(
+    agent=app,
+    config={
+        "requirements": [
+            "google-cloud-aiplatform[agent_engines,adk]",
+            "cloudpickle",
+            "pydantic",
+        ],
+        "staging_bucket": BUCKET,
+        "agent_gateway_config": {
+            "agent_to_anywhere_config": {"agent_gateway": GW},
+        },
+        "identity_type": types.IdentityType.AGENT_IDENTITY,
+        "env_vars": {
+            "GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": "False",
+        },
+    },
+)
+print("DEPLOYED:", remote.api_resource.name)

--- a/semantic-governance/demo/query_agent.py
+++ b/semantic-governance/demo/query_agent.py
@@ -1,0 +1,26 @@
+"""Query the deployed, gateway-governed agent. The 89 EUR refund should be
+DENIED by the SGP policy (over the 75 EUR limit); the 45 EUR one ALLOWED."""
+
+import vertexai
+
+PROJ = "sascha-playground-doit"
+LOC = "us-central1"
+ENGINE = f"projects/{PROJ}/locations/{LOC}/reasoningEngines/6313833922073460736"
+
+client = vertexai.Client(project=PROJ, location=LOC)
+remote = client.agent_engines.get(name=ENGINE)
+
+prompts = [
+    "Please refund order HAM-4471, the customer in Hamburg wants their 89 euros back. It shipped to Germany.",
+    "Please refund order HAM-4472 for 45 euros, the hoodie arrived damaged. It shipped to Germany.",
+]
+
+for p in prompts:
+    print("\n" + "=" * 70)
+    print("USER:", p)
+    print("-" * 70)
+    try:
+        for event in remote.stream_query(user_id="sascha", message=p):
+            print(event)
+    except Exception as e:
+        print("QUERY EXCEPTION:", type(e).__name__, str(e)[:500])

--- a/semantic-governance/skill/SKILL.md
+++ b/semantic-governance/skill/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: semantic-governance
+description: Use this skill when governing an AI agent's tool calls with a plain-English policy on Google's Gemini Enterprise Agent Platform, using Semantic Governance Policies (SGP). Covers deploying an ADK agent to Agent Runtime behind the Agent Gateway with agent identity, standing up the SGP engine and the VPC network path (PSC endpoint, network attachment, DNS peering), wiring the authz extension and policy, and creating a natural-language constraint that returns ALLOW or DENY on each proposed tool call. Tools, ADK (google-adk), vertexai agent_engines, gcloud network-services / compute / ai, Semantic Governance Policies.
+---
+
+# Semantic Governance Skill
+
+Govern an agent's tool calls with one plain-English sentence. Semantic Governance Policies (SGP) sit at the Agent Gateway and evaluate every proposed tool call against your natural-language constraint, returning ALLOW or DENY with a rationale before the tool runs. This skill reproduces, end to end, an ADK agent that gets a real DENY on an over-limit refund and a real ALLOW on an in-limit one.
+
+## Overview
+
+- Build any agent with Google's ADK and deploy it to Agent Runtime.
+- Put it behind the Agent Gateway so its model traffic is governed.
+- Attach a policy written as a sentence ("Never issue a refund greater than 75 euros.").
+- The gateway calls the SGP engine on each `:generateContent`, the engine judges the proposed tool call, and blocks it if it violates the sentence.
+
+> [!IMPORTANT]
+> Two settings must both be present AT CREATE time or the agent is silently not governed: `identity_type=AGENT_IDENTITY` and `agent_gateway_config`. Updating an existing agent does NOT retroactively enable SGP, you must deploy fresh with both.
+
+> [!IMPORTANT]
+> Use model `gemini-2.5-flash`. Confirm the model actually serves in your project/region with the SDK before deploying.
+
+> [!WARNING]
+> The docs' example model `gemini-3.5-flash` returns `404 NOT_FOUND / no access` in a normal project. Symptom, the deployed agent 500s (or, with failOpen true, returns a model 404). Swap to a model you verified serves.
+
+> [!WARNING]
+> SGP is Preview. The verdict is itself an LLM call, so it is probabilistic and adds one model round-trip of cost and latency per tool call. It does not support VPC Service Controls. Keep hard-coded checks for money-critical actions and use SGP for fuzzy-intent governance.
+
+---
+
+## Quick Start
+
+Set once. `PROJECT_ID`, `LOCATION=us-central1` (an SGP-supported region), and an application-default login (`gcloud auth application-default login`).
+
+### 1. Build and deploy the ADK agent (behind the gateway)
+
+`demo/deploy_agent.py`, the load-bearing part is the `config` dict.
+
+```python
+# pip install "google-cloud-aiplatform[agent_engines,adk]>=1.112"
+from google.adk.agents import Agent
+from vertexai import agent_engines, types
+import vertexai
+
+def issue_refund(order_id: str, amount_eur: float, ship_country: str) -> dict:
+    return {"status": "refunded", "order_id": order_id, "amount_eur": amount_eur, "ship_country": ship_country}
+
+agent = Agent(model="gemini-2.5-flash", name="merch_support_agent", tools=[issue_refund],
+              instruction="You are support for a Hamburg merch store. Call issue_refund for refund requests.")
+app = agent_engines.AdkApp(agent=agent)
+client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
+
+remote = client.agent_engines.create(agent=app, config={
+    "requirements": ["google-cloud-aiplatform[agent_engines,adk]", "cloudpickle", "pydantic"],
+    "staging_bucket": "gs://STAGING_BUCKET",
+    "agent_gateway_config": {"agent_to_anywhere_config": {"agent_gateway": GATEWAY_URI}},
+    "identity_type": types.IdentityType.AGENT_IDENTITY,
+    "env_vars": {"GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": "False"},
+})
+```
+
+> [!WARNING]
+> `env_vars` values must be strings. Passing the docs' boolean `False` raises `TypeError: Unknown value type ... Must be a str or SecretRef`. Use `"False"`.
+
+> [!WARNING]
+> The gateway (`GATEWAY_URI`) must exist BEFORE this deploy, because `agent_gateway_config` references it. Create the gateway (step 2) first.
+
+Deploying auto-registers the agent in the Agent Registry as a `projects/.../agents/agentregistry-...` resource. Find that registry name, it is what the policy's `--agent` flag needs (NOT the `reasoningEngines/...` path):
+
+```bash
+curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://agentregistry.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/agents?pageSize=100" \
+  | python3 -c "import sys,json;[print(a['name']) for a in json.load(sys.stdin)['agents'] if 'REASONING_ENGINE_ID' in json.dumps(a)]"
+```
+
+### 2. Create the egress Agent Gateway
+
+`agent-gateway-egress.yaml`:
+```yaml
+name: merch-egress-gw
+protocols: [MCP]
+googleManaged: {governedAccessPath: AGENT_TO_ANYWHERE}
+registries: ["//agentregistry.googleapis.com/projects/PROJECT_ID/locations/LOCATION"]
+```
+```bash
+gcloud network-services agent-gateways import merch-egress-gw --source=agent-gateway-egress.yaml --location=LOCATION
+```
+> [!WARNING]
+> The `import` blocks for a while and the CLI may look hung, it is a long provisioning op, the resource still lands. Verify with `... agent-gateways list`.
+
+### 3. Activate the SGP engine
+
+```bash
+curl -X PATCH "https://LOCATION-aiplatform.googleapis.com/v1beta1/projects/PROJECT_ID/locations/LOCATION/semanticGovernancePolicyEngine?updateMask=SemanticGovernancePolicyEngine" \
+  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" -H "Content-Type: application/json" -d '{}'
+# poll until state: ACTIVE, then save the pscServiceAttachment it returns
+```
+
+### 4. Build the private network path to the engine
+
+This is the step the docs bury and it is the one that makes or breaks enforcement.
+
+```bash
+# proxy-only subnet (range must NOT overlap 10.128.0.0/9 in an auto-mode network)
+gcloud compute networks subnets create sgp-proxy-subnet --network=default --region=LOCATION \
+  --range=192.168.100.0/24 --purpose=REGIONAL_MANAGED_PROXY --role=ACTIVE
+# network attachment so the gateway can reach into your VPC
+gcloud compute network-attachments create sgp-nw-attachment --region=LOCATION --subnets=default --connection-preference=ACCEPT_AUTOMATIC
+# static IP + PSC endpoint to the engine's service attachment + DNS record
+gcloud compute addresses create sgp-psc-ip --region=LOCATION --subnet=default --purpose=GCE_ENDPOINT
+IP=$(gcloud compute addresses describe sgp-psc-ip --region=LOCATION --format="value(address)")
+gcloud compute forwarding-rules create sgp-psc-ep --region=LOCATION --network=default --address=sgp-psc-ip --target-service-attachment=PSC_SERVICE_ATTACHMENT
+gcloud dns managed-zones create sgp-zone --dns-name="sgp.internal." --visibility=private --networks=default
+gcloud dns record-sets create LOCATION.sgp.internal. --zone=sgp-zone --type=A --ttl=300 --rrdatas=$IP
+```
+
+### 5. Give the gateway VPC connectivity (the linchpin)
+
+Re-import the gateway WITH a `networkConfig`. Without this the gateway cannot reach the engine, the authz callout fails, and with `failOpen:false` every model call returns `500` with no useful error.
+
+```yaml
+name: merch-egress-gw
+protocols: [MCP]
+googleManaged: {governedAccessPath: AGENT_TO_ANYWHERE}
+registries: ["//agentregistry.googleapis.com/projects/PROJECT_ID/locations/LOCATION"]
+networkConfig:
+  egress: {networkAttachment: projects/PROJECT_ID/regions/LOCATION/networkAttachments/sgp-nw-attachment}
+  dnsPeeringConfig:
+    domains: ["sgp.internal."]
+    targetProject: PROJECT_ID
+    targetNetwork: projects/PROJECT_ID/global/networks/default
+```
+```bash
+gcloud network-services agent-gateways import merch-egress-gw --source=agent-gateway-egress.yaml --location=LOCATION
+```
+> [!WARNING]
+> Allow several minutes AFTER this applies before enforcement is live. Symptom of "not live yet", the agent 500s (callout still failing). It flips to real ALLOW/DENY once the network path is up.
+
+### 6. Wire the authz callout, `demo/authz_ext.json` + `demo/authz_policy.json`
+
+```bash
+# authz extension points at the engine's DNS hostname
+curl -X POST ".../authzExtensions?authzExtensionId=sgp-authz-ext" ... -d @authz_ext.json     # service+authority = LOCATION.sgp.internal, failOpen: false
+# authz policy binds it to the gateway on the :generateContent path
+curl -X POST ".../authzPolicies?authzPolicyId=sgp-authz-policy" ... -d @authz_policy.json     # action CUSTOM, policyProfile CONTENT_AUTHZ
+```
+
+### 7. Create the policy, one sentence
+
+```bash
+CLOUDSDK_API_ENDPOINT_OVERRIDES_AIPLATFORM="https://LOCATION-aiplatform.googleapis.com/" \
+gcloud beta ai semantic-governance-policies create refund-cap \
+  --location=LOCATION --display-name="Refund cap 75 EUR" \
+  --agent="projects/PROJECT_ID/locations/LOCATION/agents/agentregistry-..." \
+  --natural-language-constraint="Never issue a refund greater than 75 euros."
+```
+> [!WARNING]
+> `--agent` wants the Agent Registry name from step 1, not the `reasoningEngines/...` path. Passing the engine path fails with `SEMANTIC_GOVERNANCE_POLICY_AGENT_INVALID_NAME`.
+
+### 8. Run it, `demo/query_agent.py`
+
+Query the deployed agent. An 89 euro refund is DENIED, a 45 euro one is ALLOWED. Verdicts also land in Cloud Logging under `logName=".../logs/semantic-governance-policy"`.
+
+```
+USER: refund the customer their 89 euros
+AGENT: I cannot proceed. 89 euros exceeds the refund cap of 75 euros.   # DENY, rationale in the SGP log
+USER: refund 45 euros
+AGENT: The refund for order HAM-4472 was processed.                     # ALLOW, tool actually ran
+```
+
+## Dependencies and Prerequisites
+
+- `google-cloud-aiplatform[agent_engines,adk] >= 1.112`, Python 3.12 (the macOS system Python is too old, use `uv venv --python 3.12`).
+- APIs enabled, `aiplatform`, `agentregistry`, `networkservices`, `networksecurity`, `compute`, `dns`.
+- SGP Preview access on the project, and an SGP-supported region (us-central1 works).
+
+## Supporting files
+
+- `demo/deploy_agent.py`, the ADK agent + the deploy config that puts it behind the gateway with agent identity.
+- `demo/query_agent.py`, drives the agent through the 89/45 euro refunds.
+- `demo/authz_ext.json`, `demo/authz_policy.json`, the gateway-to-engine callout wiring.
+
+> [!WARNING]
+> Every resource here (gateway, PSC endpoint, network attachment, SGP engine, Agent Runtime deployment) is real billable infrastructure. The PSC endpoint alone is ~$0.025/hr. Tear it all down when done. Agent Runtime itself does not bill when idle.

--- a/ternlight/.gitignore
+++ b/ternlight/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/ternlight/README.md
+++ b/ternlight/README.md
@@ -1,0 +1,21 @@
+# Ternlight, semantic search in the browser with a 7 MB WASM model
+
+Gen AI Livestream e06. On-device semantic embeddings for JavaScript, the whole model plus tokenizer plus engine in one WebAssembly file. Call `embed(text)`, get a 384-dim vector on the CPU, synchronously, no API key and no runtime download.
+
+Everything runnable lives under [`skill/`](skill/), one folder, one source of truth.
+
+- [skill/SKILL.md](skill/SKILL.md) — the skill, current facts, quick start, gotchas, and the decision guidance.
+- [skill/scripts/ternlight-search.mjs](skill/scripts/ternlight-search.mjs) — point on-device search at your own JSON corpus.
+- [skill/scripts/three-lines.mjs](skill/scripts/three-lines.mjs) and [search-demo.mjs](skill/scripts/search-demo.mjs) — the episode demos, verified.
+- [skill/web/](skill/web/) — the in-browser demo, a search box wired to the wasm.
+
+## Run it
+
+```bash
+cd skill/scripts && npm install
+node ternlight-search.mjs your-corpus.json "your query" --topK 3
+
+cd ../web && npm install && npm run dev
+```
+
+Ternlight is an open source project by [Paradane](https://www.linkedin.com/company/paradane). Package on npm, [@ternlight/base](https://www.npmjs.com/package/@ternlight/base).

--- a/ternlight/README.md
+++ b/ternlight/README.md
@@ -2,6 +2,8 @@
 
 Gen AI Livestream e06. On-device semantic embeddings for JavaScript, the whole model plus tokenizer plus engine in one WebAssembly file. Call `embed(text)`, get a 384-dim vector on the CPU, synchronously, no API key and no runtime download.
 
+Try it live, no install, everything runs in your browser: https://ternlight-demo-1051190601763.us-central1.run.app
+
 Everything runnable lives under [`skill/`](skill/), one folder, one source of truth.
 
 - [skill/SKILL.md](skill/SKILL.md) — the skill, current facts, quick start, gotchas, and the decision guidance.
@@ -16,6 +18,14 @@ cd skill/scripts && npm install
 node ternlight-search.mjs your-corpus.json "your query" --topK 3
 
 cd ../web && npm install && npm run dev
+```
+
+## Deploy the demo
+
+The browser demo is a static site, it deploys to Cloud Run as an nginx container that serves the built `dist/`. The `Dockerfile` and `nginx.conf` in `skill/web/` set the `application/wasm` MIME and gzip the engine.
+
+```bash
+gcloud run deploy ternlight-demo --source skill/web --region us-central1 --allow-unauthenticated
 ```
 
 Ternlight is an open source project by [Paradane](https://www.linkedin.com/company/paradane). Package on npm, [@ternlight/base](https://www.npmjs.com/package/@ternlight/base).

--- a/ternlight/skill/SKILL.md
+++ b/ternlight/skill/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: ternlight
+description: Use this skill when adding on-device semantic search, FAQ matching, deduplication, clustering, or RAG reranking to a JavaScript or TypeScript app with no server, no API key, and no runtime model download. Covers the @ternlight/base and @ternlight/mini WASM sentence-embedding packages, the embed / cosineSim / similar API, indexing a corpus once and searching it, and the Vite and webpack bundler setup for the browser build. Works in Node, browsers, Cloudflare Workers, Vercel Edge, Deno, and Bun.
+---
+
+# Ternlight On-Device Embeddings Skill
+
+Ternlight ships a sentence-embedding model, its tokenizer, and a from-scratch Rust inference engine inside a single WebAssembly file. You call `embed(text)` and get a 384-dim unit vector back on the CPU, synchronously, with no network call and no model download at runtime. Use it for semantic search over small-to-medium corpora, FAQ matching, dedup, and RAG reranking.
+
+> [!IMPORTANT]
+> Install one of two packages, same API, different size and quality tier.
+> `npm install @ternlight/base` is the quality tier, ~7 MB gzipped on the wire, ~5 ms per embed.
+> `npm install @ternlight/mini` is the small tier, ~5.5 MB, under 2 ms, slightly lower quality.
+> `embed()` is SYNCHRONOUS in Node and in bundled browser builds. There is no init call and no await. The model already lives inside the wasm. Latest published version is 0.1.0, MIT licensed.
+
+> [!IMPORTANT]
+> `embed(text)` returns a `Float32Array` of length 384, L2-normalized. Because vectors are unit-length, `cosineSim(a, b)` is a plain dot product. Input is tokenized with BERT WordPiece and truncated at 128 tokens, roughly 95 English words. Longer text is silently cut, so chunk your documents small.
+
+> [!WARNING]
+> In-browser embeddings are not new. transformers.js has run embedding models in the browser for years. What Ternlight adds is the packaging, a BitNet-style ternary model (weights are -1, 0, +1) small enough to bake the whole model plus tokenizer plus engine into one 7 MB wasm and call it synchronously with no runtime download. Do not claim a first-ever in-browser embedding capability, claim the size and the zero-download story.
+
+> [!WARNING]
+> The repo `docs/architecture.md` lists the model as d_model 256, 4 heads, ffn 1024, ~9.5M params. The shipped v0.1.0 engine does NOT match that. Ask the engine itself with `engineInfo()`, which reports `tern-engine v1 | embedding_format=int4 | vocab=30522 d_model=384 n_layers=2 n_heads=6 ffn_dim=1536 output_dim=384 max_seq_len=128`. When the doc and the binary disagree, trust the binary.
+
+---
+
+## Quick Start
+
+Node, three lines, no async anywhere.
+
+```js
+import { embed, cosineSim, similar } from '@ternlight/base';
+
+// two ways of asking the same thing sit close together
+cosineSim(embed('reset my password'), embed('I forgot my password')); // 0.884
+
+// top-K semantic search over any list of strings
+similar('how do I reset my password', [
+  'Resetting a forgotten password',
+  'Update your billing address',
+  'Track the status of your delivery',
+], { topK: 2 });
+// [{ text: 'Resetting a forgotten password', sim: ... }, ...]
+```
+
+For repeated searches over the same corpus, embed it ONCE up front and reuse the vectors. This is the pattern you want in any real app.
+
+```js
+import { embed, cosineSim } from '@ternlight/base';
+
+const docs = [ /* your strings */ ];
+const index = docs.map((text) => ({ text, v: embed(text) })); // one-time cost
+
+function search(query, topK = 3) {
+  const q = embed(query);
+  return index
+    .map(({ text, v }) => ({ text, sim: cosineSim(q, v) }))
+    .sort((a, b) => b.sim - a.sim)
+    .slice(0, topK);
+}
+```
+
+> [!WARNING]
+> The very first `embed()` call in a process pays a one-time wasm warmup of roughly 200 ms. After that, each embed is a few milliseconds. Measured on an M-series CPU, indexing 10 short docs in a warm process took about 8 ms total, and each query embed was 2.5 to 5 ms. Do the corpus indexing once at startup, never per request.
+
+### Browser with Vite
+
+The browser build imports the wasm as an ES module asset, so Vite needs the wasm plugin. That is the entire setup.
+
+```js
+// vite.config.js
+import wasm from 'vite-plugin-wasm';
+export default { plugins: [wasm()] };
+```
+
+```js
+// main.js — same embed/cosineSim/similar API as Node
+import { embed, cosineSim, engineInfo } from '@ternlight/base';
+```
+
+> [!WARNING]
+> Do not add `vite-plugin-top-level-await` on Vite 8. It pulls a `rollup` peer that the rolldown-based Vite 8 does not expose, and the build dies with `Cannot find module 'rollup'`. The wasm plugin alone is enough on modern targets. On webpack 5 the equivalent is `experiments: { asyncWebAssembly: true }`. Node needs no config at all.
+
+> [!IMPORTANT]
+> Every search runs fully client-side. Verified in a real browser, after loading the page and running five searches, the total resource count stayed at exactly two, the JS glue and the one-time wasm fetch. No query fires a network request. The user's search text never leaves the tab.
+
+## When to use it, and when not
+
+Measured behavior and honest limits, all confirmed on real runs.
+
+- **Corpus size.** This is a small-to-medium tool, hundreds to low thousands of chunks, embed once and brute-force cosine. For hundreds of thousands of documents, reach for a real vector database instead.
+- **Quality.** The authors report 0.844 Spearman versus all-MiniLM-L6-v2 for base, 0.835 for mini, and 0.465 SciFact NDCG@10. In practice, the README examples reproduce exactly, `reset my password` versus `I forgot my password` scores 0.884. Idiomatic paraphrases with zero shared words score lower, `how do I go live on the stream` versus `start broadcasting my show` was only 0.403. Ranking still works because relative order is what matters, but keep the similarity score visible so a weak match reads honestly.
+- **Token cap.** 128 tokens, silently truncated. Chunk before you embed.
+- **Indexing cost is real on big corpora.** A large corpus embedded on page load will pin the CPU for a noticeable moment. Pre-compute the vectors and cache them, do not re-index on every visit.
+
+## Workflow
+
+When the request is to search a user's own data, use the parameterized script rather than hand-writing a loop.
+
+1. Put the corpus in a JSON file, an array of strings or of `{ text }` objects.
+2. Run `node scripts/ternlight-search.mjs <corpus.json> "<query>" [--topK N]`.
+3. Report the ranked matches and their scores back.
+
+```bash
+node scripts/ternlight-search.mjs kb.json "how do I catch an error" --topK 3
+# 0.577  Handle exceptions with try and except blocks
+# ...
+```
+
+## Dependencies and Prerequisites
+
+- Node >= 18. `npm install @ternlight/base` (or `@ternlight/mini`).
+- Browser build additionally needs `vite-plugin-wasm` on Vite, or `experiments: { asyncWebAssembly: true }` on webpack 5.
+- No API key, no service account, no GPU, nothing to authenticate.
+
+## Supporting files
+
+- [scripts/ternlight-search.mjs](scripts/ternlight-search.mjs) — the parameterized utility, point it at your own JSON corpus. `node scripts/ternlight-search.mjs corpus.json "your query" --topK 3`
+- [scripts/three-lines.mjs](scripts/three-lines.mjs) — frozen episode reproduction, the embed and cosineSim intro. `node scripts/three-lines.mjs`
+- [scripts/search-demo.mjs](scripts/search-demo.mjs) — frozen episode reproduction, index a small corpus and run a few queries. `node scripts/search-demo.mjs`
+- [web/](web/) — the in-browser demo, a search box wired to the wasm. `cd web && npm install && npm run dev`
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing code against this package. These are the source of truth for the API shape, the quality numbers, and the bundler setup, do not rely solely on the examples above.
+
+- https://github.com/soycaporal/ternlight
+- https://www.npmjs.com/package/@ternlight/base
+- https://github.com/soycaporal/ternlight/blob/main/docs/architecture.md
+
+Ternlight is an open source project by Paradane, https://www.linkedin.com/company/paradane.
+
+## From the episode
+
+Gen AI Livestream e06, semantic search in the browser with a 7 MB WASM model. Video link to follow.

--- a/ternlight/skill/scripts/package.json
+++ b/ternlight/skill/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ternlight-scripts",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ternlight/base": "^0.1.0"
+  }
+}

--- a/ternlight/skill/scripts/search-demo.mjs
+++ b/ternlight/skill/scripts/search-demo.mjs
@@ -1,0 +1,45 @@
+// Beat 2 — turn embed into a real search. Index a small help corpus once, then query it.
+// Run: node 02-search.mjs
+import { embed, cosineSim } from '@ternlight/base';
+
+// A tiny creator help center for the show. In a real app these come from your CMS.
+const docs = [
+  'Going live: press the Go Live button to start broadcasting your stream',
+  'Scheduling posts: queue a post and it publishes automatically at the time you set',
+  'Time zones: streams default to Europe Berlin, change it under settings',
+  'Refunds: how to request a refund on a paid membership',
+  'Overlays: add a lower third or a standby screen to your scene',
+  'Chat moderation: ban, timeout, or slow mode your live chat',
+  'Uploading a thumbnail: replace the auto thumbnail with your own image',
+  'Billing: update the card on file for your subscription',
+  'Multistream: send one broadcast to YouTube and LinkedIn at the same time',
+  'Clips: cut a short highlight from a past broadcast to share',
+];
+
+// Index once. This is the upfront cost, embed every doc a single time.
+const t0 = performance.now();
+const index = docs.map((text) => ({ text, v: embed(text) }));
+const indexMs = performance.now() - t0;
+console.log(`indexed ${docs.length} docs in ${indexMs.toFixed(1)} ms\n`);
+
+function search(query, topK = 3) {
+  const q = embed(query);
+  return index
+    .map(({ text, v }) => ({ text, sim: cosineSim(q, v) }))
+    .sort((a, b) => b.sim - a.sim)
+    .slice(0, topK);
+}
+
+for (const query of [
+  'how do I start streaming',
+  'schedule my content ahead of time',
+  'what time zone are broadcasts in',
+  'send my stream to two platforms at once',
+]) {
+  const t = performance.now();
+  const hits = search(query);
+  const ms = performance.now() - t;
+  console.log(`Q: ${query}   (${ms.toFixed(1)} ms)`);
+  for (const h of hits) console.log(`   ${h.sim.toFixed(3)}  ${h.text}`);
+  console.log();
+}

--- a/ternlight/skill/scripts/ternlight-search.mjs
+++ b/ternlight/skill/scripts/ternlight-search.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// ternlight-search — point on-device semantic search at YOUR own list of strings.
+//
+// Usage:
+//   node ternlight-search.mjs <corpus.json> "<query>" [--topK 3]
+//
+// corpus.json is a JSON array of strings, or an array of { text, ... } objects.
+// Embeds the corpus once, embeds the query, prints the top-K by cosine similarity.
+// Pure local WASM inference, no API key, no network.
+import { readFileSync } from 'node:fs';
+import { embed, cosineSim, engineInfo } from '@ternlight/base';
+
+const args = process.argv.slice(2);
+if (args.length < 2) {
+  console.error('usage: node ternlight-search.mjs <corpus.json> "<query>" [--topK N]');
+  process.exit(1);
+}
+const [corpusPath, query] = args;
+const topKFlag = args.indexOf('--topK');
+const topK = topKFlag !== -1 ? Number(args[topKFlag + 1]) : 3;
+
+const raw = JSON.parse(readFileSync(corpusPath, 'utf8'));
+// accept ["str", ...] or [{text:"str"}, ...]
+const docs = raw.map((d) => (typeof d === 'string' ? d : d.text));
+
+console.error(engineInfo());
+const t0 = performance.now();
+const index = docs.map((text) => ({ text, v: embed(text) }));
+console.error(`indexed ${docs.length} docs in ${(performance.now() - t0).toFixed(1)} ms\n`);
+
+const qv = embed(query);
+const hits = index
+  .map(({ text, v }) => ({ text, sim: cosineSim(qv, v) }))
+  .sort((a, b) => b.sim - a.sim)
+  .slice(0, topK);
+
+console.log(`query: ${query}\n`);
+for (const h of hits) console.log(`${h.sim.toFixed(3)}  ${h.text}`);

--- a/ternlight/skill/scripts/three-lines.mjs
+++ b/ternlight/skill/scripts/three-lines.mjs
@@ -1,0 +1,25 @@
+// Beat 1 — the three lines. embed, cosineSim, no async init.
+// Run: node 01-three-lines.mjs
+import { embed, cosineSim, engineInfo } from '@ternlight/base';
+
+console.log('engine:', engineInfo());
+
+// text -> 384-dim L2-normalized Float32Array, synchronous, no await anywhere
+const v = embed('how do I go live on the stream');
+console.log('embed() ->', v.constructor.name, 'length', v.length);
+
+// two ways of saying the same creator task should sit close together
+console.log(
+  'go live vs start broadcasting :',
+  cosineSim(embed('how do I go live on the stream'), embed('start broadcasting my show')).toFixed(3),
+);
+console.log(
+  'schedule vs queue for tomorrow:',
+  cosineSim(embed('schedule this post for later'), embed('queue it to publish tomorrow')).toFixed(3),
+);
+
+// an unrelated pair should sit far apart, that contrast is the whole point
+console.log(
+  'go live vs refund policy     :',
+  cosineSim(embed('how do I go live on the stream'), embed('what is your refund policy')).toFixed(3),
+);

--- a/ternlight/skill/web/.dockerignore
+++ b/ternlight/skill/web/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.gitignore
+Dockerfile
+.dockerignore

--- a/ternlight/skill/web/Dockerfile
+++ b/ternlight/skill/web/Dockerfile
@@ -1,0 +1,12 @@
+# Build the Vite app, then serve the static dist with nginx on Cloud Run's port.
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080

--- a/ternlight/skill/web/index.html
+++ b/ternlight/skill/web/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ternlight in-browser search</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 720px; margin: 3rem auto; padding: 0 1rem; color: #1c1a2e; }
+      h1 { font-size: 1.4rem; }
+      .badge { display: inline-block; background: #efe9ff; color: #5b45b8; padding: 2px 10px; border-radius: 999px; font-size: 0.8rem; font-weight: 600; }
+      input { width: 100%; font-size: 1.1rem; padding: 0.8rem 1rem; border: 2px solid #ddd; border-radius: 12px; box-sizing: border-box; }
+      .meta { color: #666; font-size: 0.85rem; margin: 0.6rem 0 1rem; }
+      .hit { padding: 0.7rem 0.9rem; border: 1px solid #eee; border-radius: 10px; margin: 0.4rem 0; display: flex; gap: 0.8rem; }
+      .sim { font-variant-numeric: tabular-nums; color: #5b45b8; font-weight: 600; min-width: 3.2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Ternlight, semantic search <span class="badge">no API call</span></h1>
+    <p class="meta" id="engine">loading engine...</p>
+    <input id="q" placeholder="Ask about the stream, e.g. how do I start streaming" autocomplete="off" />
+    <p class="meta" id="stat"></p>
+    <div id="results"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/ternlight/skill/web/main.js
+++ b/ternlight/skill/web/main.js
@@ -1,0 +1,46 @@
+import { embed, cosineSim, engineInfo } from '@ternlight/base';
+
+// Same creator help corpus as the Node demo. In a real app these come from your CMS.
+const docs = [
+  'Going live: press the Go Live button to start broadcasting your stream',
+  'Scheduling posts: queue a post and it publishes automatically at the time you set',
+  'Time zones: streams default to Europe Berlin, change it under settings',
+  'Refunds: how to request a refund on a paid membership',
+  'Overlays: add a lower third or a standby screen to your scene',
+  'Chat moderation: ban, timeout, or slow mode your live chat',
+  'Uploading a thumbnail: replace the auto thumbnail with your own image',
+  'Billing: update the card on file for your subscription',
+  'Multistream: send one broadcast to YouTube and LinkedIn at the same time',
+  'Clips: cut a short highlight from a past broadcast to share',
+];
+
+document.getElementById('engine').textContent = engineInfo();
+
+// Index once at load. Every search after this is pure local math, no network.
+const t0 = performance.now();
+const index = docs.map((text) => ({ text, v: embed(text) }));
+const indexMs = (performance.now() - t0).toFixed(0);
+
+const q = document.getElementById('q');
+const stat = document.getElementById('stat');
+const results = document.getElementById('results');
+stat.textContent = `indexed ${docs.length} docs in ${indexMs} ms — now type, every keystroke searches locally`;
+
+function render(query) {
+  if (!query.trim()) { results.innerHTML = ''; return; }
+  const t = performance.now();
+  const qv = embed(query);
+  const hits = index
+    .map(({ text, v }) => ({ text, sim: cosineSim(qv, v) }))
+    .sort((a, b) => b.sim - a.sim)
+    .slice(0, 3);
+  const ms = (performance.now() - t).toFixed(1);
+  stat.textContent = `searched ${docs.length} docs in ${ms} ms, no network request`;
+  results.innerHTML = hits
+    .map((h) => `<div class="hit"><span class="sim">${h.sim.toFixed(3)}</span><span>${h.text}</span></div>`)
+    .join('');
+}
+
+q.addEventListener('input', (e) => render(e.target.value));
+// expose for automated verification
+window.__ternSearch = render;

--- a/ternlight/skill/web/nginx.conf
+++ b/ternlight/skill/web/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # nginx:alpine mime.types already maps .wasm -> application/wasm.
+    # gzip the wasm and js so the 10 MB engine ships as ~7 MB on the wire.
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_types application/javascript application/wasm text/css;
+
+    # hashed build assets never change, cache them hard
+    location /assets/ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/ternlight/skill/web/package.json
+++ b/ternlight/skill/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ternlight-web-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ternlight/base": "^0.1.0"
+  },
+  "devDependencies": {
+    "vite": "^8.1.4",
+    "vite-plugin-wasm": "^3.6.0"
+  }
+}

--- a/ternlight/skill/web/vite.config.js
+++ b/ternlight/skill/web/vite.config.js
@@ -1,0 +1,7 @@
+import wasm from 'vite-plugin-wasm';
+
+// The ternlight browser build imports the .wasm as an ESM asset, so Vite needs
+// the wasm plugin. That is the whole bundler setup.
+export default {
+  plugins: [wasm()],
+};


### PR DESCRIPTION
## What

Adds the `semantic-governance/` topic: an agent skill + verified demo for governing an ADK agent's tool calls with a plain-English policy on Google's Gemini Enterprise Agent Platform (Semantic Governance Policies).

## Verified end to end

An ADK agent deployed to Agent Runtime, behind the Agent Gateway with agent identity, governed by a one-sentence policy `"Never issue a refund greater than 75 euros."`:

- **89 EUR refund → DENY** (rationale logged in the SGP verdict log)
- **45 EUR refund → ALLOW** (tool actually ran)

Reproduced twice in `sascha-playground-doit` / `us-central1`.

## Contents

- `semantic-governance/skill/SKILL.md` — step-by-step reproducible setup (deploy behind the gateway → SGP engine → the VPC network path → authz wiring → the sentence policy → run), with every gotcha inline as a callout.
- `semantic-governance/demo/` — `deploy_agent.py`, `query_agent.py`, and the authz JSON.

## Sharp edges captured (so nobody loses the hours I did)

- The gateway needs a `networkConfig` into your VPC (network attachment + DNS peering) or the callout silently fails and every model call 500s.
- The docs' example model `gemini-3.5-flash` 404s; use `gemini-2.5-flash` (confirm with the SDK first).
- `--agent` wants the Agent Registry name, not the reasoningEngine path.
- SGP is Preview: probabilistic verdict, one model call per tool call (real cost + latency), no VPC-SC.

Install: `npx skills add github.com/SaschaHeyer/gen-ai-livestream/tree/main/semantic-governance/skill`