### PR TITLE
e12 gemini token cost: thinking tokens are billed as output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,12 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+# .env alone does not match siblings like ".env copy" or ".env.local", which is
+# how a credentials file ends up sitting untracked in a PUBLIC repo waiting for
+# someone to `git add -A`. Glob the whole family, keep the example trackable.
+.env*
+!.env.example
+!.env.sample
 .venv
 env/
 venv/

--- a/gemini-token-cost/README.md
+++ b/gemini-token-cost/README.md
@@ -1,0 +1,54 @@
+# Gemini token cost
+
+What a Gemini prompt actually costs you, including the thinking tokens you never see.
+
+The Interactions API reports thinking separately from output, and Google bills thinking at the
+full output rate. Cost off the visible field alone and you can understate the output bill by more
+than thirty times on short answer workloads.
+
+## The skill
+
+Everything reusable lives in [skill/](skill/), install that folder.
+
+- [skill/SKILL.md](skill/SKILL.md), the current facts, the sharp edges, and the measured numbers
+- [skill/scripts/tokencost.py](skill/scripts/tokencost.py), point it at your own prompt
+
+```bash
+export GEMINI_API_KEY=...
+pip install -U google-genai
+python skill/scripts/tokencost.py "Explain why database indexes slow down writes." --repeat 3
+```
+
+## The episode demos
+
+[demo/](demo/) holds the exact scripts run on the stream, kept as the reproduction.
+
+| file | what it shows |
+| --- | --- |
+| `probe_usage.py` | dumps the whole `usage` object, this is where the thinking field turns up |
+| `compare.py` | the A/B comparison across two models and two workload shapes |
+| `sampling_check.py` | what the API does when you send the deprecated sampling parameters |
+| `sampling_honored.py` | whether `temperature` is actually honoured, it is not |
+
+```bash
+pip install -r demo/requirements.txt
+python demo/compare.py --shape output-heavy --repeat 3
+python demo/compare.py --shape input-heavy --repeat 3
+```
+
+## What we measured
+
+2026-07-21, `google-genai==2.12.1`, Python 3.13.3, 3 samples per model,
+`gemini-3.5-flash` against `gemini-3.6-flash`.
+
+| workload shape | visible output | thinking | cost |
+| --- | --- | --- | --- |
+| long answer | 16.3 percent fewer | 5.7 percent fewer | 28.0 percent cheaper |
+| long context, short answer | 26.7 percent fewer | 32.3 percent fewer | 36.6 percent cheaper |
+
+Google's claim of 17 percent fewer output tokens reproduced at 16.3 percent on the long answer
+shape. The long context shape saved more, not less, even though the input price never moved,
+because thinking dominates that bill.
+
+Single runs of the same comparison gave 43.6 and 48.4 percent. Three samples gave 28.0. Sample
+size matters more than the model choice here.

--- a/gemini-token-cost/demo/compare.py
+++ b/gemini-token-cost/demo/compare.py
@@ -1,0 +1,110 @@
+"""Compare what the same task actually costs on two Gemini models.
+
+Reads real token counts off the usage object and multiplies by the published
+per-million prices. The point of the script is that the billed output is
+output tokens PLUS thought tokens, not the output tokens alone.
+"""
+import argparse
+import os
+from google import genai
+
+# Published prices, USD per 1M tokens, standard paid tier.
+# Source, https://ai.google.dev/gemini-api/docs/pricing
+PRICES = {
+    "gemini-3.5-flash": {"input": 1.50, "output": 9.00},
+    "gemini-3.6-flash": {"input": 1.50, "output": 7.50},
+    "gemini-3.5-flash-lite": {"input": 0.30, "output": 2.50},
+}
+
+OUTPUT_HEAVY = (
+    "Write a detailed runbook for taking a weekly technical livestream to air. "
+    "Cover the rehearsal pass, the scene layout in the streaming software, audio "
+    "checks, what to cache as a fallback when a live demo fails, and how to close "
+    "the show. Be thorough and use clear sections."
+)
+
+INPUT_HEAVY_QUESTION = (
+    "Read the notes above. In one sentence, name the single biggest risk to the stream."
+)
+
+
+def measure(client, model, prompt):
+    interaction = client.interactions.create(model=model, input=prompt)
+    u = interaction.usage
+    thought = u.total_thought_tokens or 0
+    visible = u.total_output_tokens or 0
+    billed_output = visible + thought
+    p = PRICES[model]
+    cost = (u.total_input_tokens / 1e6) * p["input"] + (billed_output / 1e6) * p["output"]
+    return {
+        "model": model,
+        "input": u.total_input_tokens,
+        "visible_output": visible,
+        "thought": thought,
+        "billed_output": billed_output,
+        "total_tokens": u.total_tokens,
+        "cost": cost,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shape", choices=["output-heavy", "input-heavy"], default="output-heavy")
+    ap.add_argument("--models", nargs="+", default=["gemini-3.5-flash", "gemini-3.6-flash"])
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="samples per model, thinking tokens vary a lot so 1 is an anecdote")
+    args = ap.parse_args()
+
+    client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+    if args.shape == "output-heavy":
+        prompt = OUTPUT_HEAVY
+    else:
+        with open("fixtures/long-input.txt") as fh:
+            prompt = fh.read() + "\n\n" + INPUT_HEAVY_QUESTION
+
+    print(f"shape, {args.shape}, {args.repeat} sample(s) per model")
+    print()
+    header = f"{'model':<24}{'in':>8}{'visible':>10}{'thought':>10}{'billed out':>12}{'cost USD':>12}"
+    print(header)
+    print("-" * len(header))
+
+    means = []
+    for model in args.models:
+        samples = [measure(client, model, prompt) for _ in range(args.repeat)]
+        for r in samples:
+            print(
+                f"{r['model']:<24}{r['input']:>8}{r['visible_output']:>10}"
+                f"{r['thought']:>10}{r['billed_output']:>12}{r['cost']:>12.6f}"
+            )
+        mean = {k: sum(s[k] for s in samples) / len(samples)
+                for k in ("input", "visible_output", "thought", "billed_output", "cost")}
+        mean["model"] = model
+        mean["cost_min"] = min(s["cost"] for s in samples)
+        mean["cost_max"] = max(s["cost"] for s in samples)
+        means.append(mean)
+        if args.repeat > 1:
+            print(
+                f"{'  mean':<24}{mean['input']:>8.0f}{mean['visible_output']:>10.0f}"
+                f"{mean['thought']:>10.0f}{mean['billed_output']:>12.0f}{mean['cost']:>12.6f}"
+            )
+            print(f"{'  cost range':<24}{mean['cost_min']:.6f} to {mean['cost_max']:.6f}")
+        print()
+
+    if len(means) == 2:
+        a, b = means
+        for label, key in (("visible output tokens", "visible_output"),
+                           ("thinking tokens", "thought"),
+                           ("billed output tokens", "billed_output")):
+            if a[key]:
+                print(f"{label}, {b['model']} vs {a['model']}, {(a[key] - b[key]) / a[key] * 100:+.1f} percent")
+        if a["cost"]:
+            print(f"cost, {b['model']} vs {a['model']}, {(a['cost'] - b['cost']) / a['cost'] * 100:+.1f} percent")
+        print()
+        print("positive percent means the newer model used less or cost less")
+        if args.repeat == 1:
+            print("one sample per model, treat this as an anecdote, rerun with --repeat 3")
+
+
+if __name__ == "__main__":
+    main()

--- a/gemini-token-cost/demo/fixtures/long-input.txt
+++ b/gemini-token-cost/demo/fixtures/long-input.txt
@@ -1,0 +1,120 @@
+STAGE STUDIO, PRODUCTION NOTES, SEPTEMBER BLOCK
+Internal working notes for the Friday technical livestream. Compiled in Hamburg.
+
+--- SHOW FORMAT ---
+
+The show airs Friday afternoon Central European Time and runs between forty five and
+sixty minutes. The format is fixed by now and the audience expects it. A cold open of
+about ninety seconds with no housekeeping, then a why it matters segment of three to
+five minutes, then the build which is the bulk of the show at twenty to thirty minutes
+across two to four beats, then a sharp edges segment of about five minutes, then the
+distill and ship segment where the week's skill gets merged live, then a short call to
+action and a tease for the following week.
+
+The build segment is where the host directs an agent and narrates the decisions while
+the agent types. This is the part viewers come for. It is also the part most likely to
+break on air, which is why every build beat carries a cached fallback artifact captured
+the day before.
+
+--- SCENE LAYOUT IN THE STREAMING SOFTWARE ---
+
+Scene one, standby. A static card with the episode headline, the wordmark, and a countdown
+timer. Music bed at low volume. This scene runs for five minutes before air while the
+audience assembles in chat.
+
+Scene two, camera full. Host on camera, no screen share. Used for the cold open, parts of
+why it matters, and the close. Lower third shows the host name and the episode subtitle.
+
+Scene three, screen with camera inset. The main working scene. Editor or terminal fills the
+frame, host camera sits bottom right at roughly one fifth width. This is where the build
+beats happen. The inset must never cover the terminal's last four lines, which is where
+command output lands.
+
+Scene four, slides. Full screen deck, no camera. Used for the pricing table, any diagram,
+and the takeaway card. Presenter mode runs on the second display so the speaker notes are
+visible to the host only.
+
+Scene five, browser. Full screen browser for documentation, the repository page, and the
+moment the skill gets pushed and the page is refreshed live.
+
+Scene six, be right back. Used only if something goes badly wrong and the host needs sixty
+seconds to recover. Has never been used on air but staged every week regardless.
+
+--- AUDIO CHAIN ---
+
+Microphone into the interface, interface into the machine over USB. Gain staged so normal
+speech peaks around minus twelve decibels with headroom for laughter and emphasis. A gate
+sits before the compressor to keep keyboard noise out of the quiet gaps, threshold tuned so
+typing is audible but not distracting, because viewers actually like hearing the typing
+during a build beat. Compressor at a gentle ratio, roughly three to one, just to even out
+the difference between the host leaning in and leaning back.
+
+Monitoring is closed back headphones, never speakers, because the stream audio would loop
+back into the microphone. The host checks monitoring in the first thirty seconds of standby
+every single week. This has caught a dead cable twice.
+
+Music beds only during standby and the closing card. Never under speech, never under a demo.
+
+--- REHEARSAL PASS ---
+
+The rehearsal happens the day before, not the morning of. It runs every demo beat end to
+end with the real environment, the real credentials, and the real network, and it captures
+the output of each beat as a fallback artifact. A demo that has not been run end to end in
+the last twenty four hours is not considered verified.
+
+The rehearsal also times each beat. The outline carries target times and the rehearsal is
+where those times get corrected. A build beat that overruns by four minutes eats the sharp
+edges segment, and sharp edges is the segment viewers trust most, so it is protected.
+
+Anything that fails rehearsal twice gets swapped so that the cached artifact becomes the
+primary and the live attempt becomes the bonus. Live retries are only for demos that have
+already been rehearsed clean.
+
+--- WHAT GETS CACHED AS A FALLBACK ---
+
+Every build beat has exactly one fallback artifact and it lives in the episode's assets
+folder under plan b, named by beat number. For a command line beat that is the terminal
+output saved as text. For a beat that produces an image or a video that is the generated
+file itself. For a beat that takes a long time to run that is a pre computed result so the
+host can show the answer without waiting on air.
+
+The rule about fallbacks is that the host says plainly when one is being used. Pretending a
+cached run is live is the fastest way to lose an audience that is mostly engineers. Saying
+this is from yesterday because the API is slow right now costs nothing and buys trust.
+
+--- CREDENTIALS AND ENVIRONMENT ---
+
+Keys come from the secret manager, never from a file in the repository and never from the
+system keychain. The read is scripted so it happens the same way every week. If the read
+fails, that failure is the thing to fix, it is not a reason to go hunting for a key
+somewhere else.
+
+The environment gets a version check before every episode. The interpreter version, the SDK
+version, and the model identifiers all get printed and pinned into the preparation notes. A
+package silently resolving to an older version because the interpreter is old has caused a
+false report that a vendor never shipped a feature, so the check is not optional.
+
+--- CLOSING THE SHOW ---
+
+The close is short. The skill is already merged and pushed by this point, so the call to
+action is simply to go and install it and report back. Then the article promise, then the
+social handle, then the tease for next week which stays deliberately vague. Then a warm
+sign off. The host does not read metrics on air and does not beg for subscriptions.
+
+After the stream the recording gets trimmed, chapters get generated from the run of show,
+the description gets filled with real timestamps, and the article gets updated with the
+video link and anything the stream surfaced that the preparation pass did not.
+
+--- KNOWN RISKS THIS BLOCK ---
+
+Network at the studio has been unstable on Friday afternoons, twice in the last two months,
+both times recovering within a minute. Mitigation is a phone hotspot on standby and the
+fallback artifacts.
+
+Model endpoints occasionally slow down under load, which matters for any beat that makes a
+long generation call on air. Mitigation is to keep the on air prompts modest and to have
+the pre computed run ready.
+
+The second display has dropped out of the streaming software's source list after a system
+update. Mitigation is to confirm the slides scene shows the deck during standby, not at the
+moment the deck is needed.

--- a/gemini-token-cost/demo/probe_usage.py
+++ b/gemini-token-cost/demo/probe_usage.py
@@ -1,0 +1,29 @@
+"""Probe what the usage object actually looks like, so the meter reads the right field."""
+import os
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+interaction = client.interactions.create(
+    model="gemini-3.6-flash",
+    input="Name three things worth checking before a livestream goes live.",
+)
+
+usage = interaction.usage
+print("type:", type(usage).__name__)
+print()
+print("--- all non-private attributes ---")
+for name in dir(usage):
+    if name.startswith("_"):
+        continue
+    value = getattr(usage, name)
+    if callable(value):
+        continue
+    print(f"{name} = {value!r}")
+
+print()
+print("--- model_dump ---")
+try:
+    print(usage.model_dump())
+except Exception as exc:
+    print("no model_dump:", exc)

--- a/gemini-token-cost/demo/requirements.txt
+++ b/gemini-token-cost/demo/requirements.txt
@@ -1,0 +1,1 @@
+google-genai==2.12.1

--- a/gemini-token-cost/demo/sampling_check.py
+++ b/gemini-token-cost/demo/sampling_check.py
@@ -1,0 +1,36 @@
+"""What actually happens when you still send the deprecated sampling parameters.
+
+The July 21 changelog deprecates temperature, top_p and top_k and does not say
+what replaces them or whether existing code keeps working. So we ask the API.
+"""
+import os
+import warnings
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+PROMPT = "In one sentence, what makes a livestream demo trustworthy?"
+
+
+def attempt(label, **kwargs):
+    print(f"--- {label}")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            interaction = client.interactions.create(
+                model="gemini-3.6-flash", input=PROMPT, **kwargs
+            )
+            print("  result, accepted")
+            print(f"  output tokens, {interaction.usage.total_output_tokens}")
+        except Exception as exc:
+            print(f"  result, raised {type(exc).__name__}")
+            print(f"  message, {str(exc)[:400]}")
+        for w in caught:
+            print(f"  warning, {w.category.__name__}, {w.message}")
+    print()
+
+
+attempt("baseline, no sampling parameters")
+attempt("temperature=0.2 as a top level argument", temperature=0.2)
+attempt("temperature inside generation_config", generation_config={"temperature": 0.2})
+attempt("top_p=0.8 as a top level argument", top_p=0.8)
+attempt("top_k=40 as a top level argument", top_k=40)

--- a/gemini-token-cost/demo/sampling_honored.py
+++ b/gemini-token-cost/demo/sampling_honored.py
@@ -1,0 +1,48 @@
+"""Is temperature inside generation_config actually honored, or silently swallowed?
+
+Accepted is not the same as honored. Two probes.
+  1. Send an out of range value. If the API validates it, it is parsing the field.
+  2. Send temperature 0 repeatedly. If it is honored, greedy decoding should make
+     the answers identical. If they vary, the field is being ignored.
+"""
+import os
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+PROMPT = (
+    "Name one German city worth visiting. Answer with the city name only, nothing else."
+)
+N = 5
+
+
+def ask(**cfg):
+    interaction = client.interactions.create(
+        model="gemini-3.6-flash", input=PROMPT, **cfg
+    )
+    return (interaction.output_text or "").strip()
+
+
+print("--- probe 1, out of range temperature 999, does the API validate the field")
+try:
+    print("  answer:", ask(generation_config={"temperature": 999}))
+    print("  result, NOT rejected, so the field is likely ignored")
+except Exception as exc:
+    print(f"  result, rejected, {type(exc).__name__}")
+    print(f"  message, {str(exc)[:300]}")
+    print("  reading, the API parsed and validated the field, so it is not ignored")
+
+print()
+for label, cfg in (
+    ("probe 2, temperature 0.0", {"generation_config": {"temperature": 0.0}}),
+    ("probe 3, temperature 2.0", {"generation_config": {"temperature": 2.0}}),
+    ("probe 4, no config at all", {}),
+):
+    answers = [ask(**cfg) for _ in range(N)]
+    print(f"--- {label}, {N} times")
+    for a in answers:
+        print("  ", a)
+    print(f"  distinct answers, {len(set(answers))} of {N}")
+    print()
+
+print("reading, if temperature 0.0 is far more consistent than temperature 2.0,")
+print("the parameter is still being honored despite the deprecation notice")

--- a/gemini-token-cost/demo/thinking_levels.py
+++ b/gemini-token-cost/demo/thinking_levels.py
@@ -1,0 +1,87 @@
+"""Does thinking_level move the bill, and by how much?
+
+Thinking dominates the invoice on short answer work. The 3.6 Flash release
+ships a knob for it. This measures the knob rather than trusting the label.
+
+  python thinking_levels.py --repeat 3
+  python thinking_levels.py --model gemini-3.5-flash-lite --shape output-heavy
+"""
+import argparse
+import os
+
+from google import genai
+
+PRICES = {
+    "gemini-3.6-flash": {"input": 1.50, "output": 7.50},
+    "gemini-3.5-flash-lite": {"input": 0.30, "output": 2.50},
+}
+
+OUTPUT_HEAVY = (
+    "Write a detailed runbook for taking a weekly technical livestream to air. "
+    "Cover the rehearsal pass, the scene layout in the streaming software, audio "
+    "checks, what to cache as a fallback when a live demo fails, and how to close "
+    "the show. Be thorough and use clear sections."
+)
+INPUT_HEAVY_Q = "In one sentence, name the single biggest risk to the stream."
+
+
+def measure(client, model, prompt, level):
+    cfg = {"generation_config": {"thinking_level": level}} if level else {}
+    interaction = client.interactions.create(model=model, input=prompt, **cfg)
+    u = interaction.usage
+    visible = u.total_output_tokens or 0
+    thought = u.total_thought_tokens or 0
+    billed = visible + thought
+    p = PRICES[model]
+    cost = (u.total_input_tokens or 0) / 1e6 * p["input"] + billed / 1e6 * p["output"]
+    return {"visible": visible, "thought": thought, "billed": billed, "cost": cost}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="gemini-3.6-flash", choices=list(PRICES))
+    ap.add_argument("--shape", default="input-heavy", choices=["input-heavy", "output-heavy"])
+    ap.add_argument("--repeat", type=int, default=3)
+    ap.add_argument("--levels", nargs="+", default=["default", "low", "high"],
+                    help="use the word default for no thinking_level at all")
+    args = ap.parse_args()
+
+    levels = [None if lvl == "default" else lvl for lvl in args.levels]
+
+    if args.shape == "output-heavy":
+        prompt = OUTPUT_HEAVY
+    else:
+        with open("fixtures/long-input.txt") as fh:
+            prompt = fh.read() + "\n\n" + INPUT_HEAVY_Q
+
+    client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+    print(f"model {args.model}, shape {args.shape}, {args.repeat} sample(s) per level")
+    print()
+    header = (f"{'thinking_level':<16}{'visible':>9}{'thought':>9}{'billed':>9}"
+              f"{'cost USD':>12}{'vs default':>13}")
+    print(header)
+    print("-" * len(header))
+
+    baseline = None
+    for level in levels:
+        try:
+            rows = [measure(client, args.model, prompt, level) for _ in range(args.repeat)]
+        except Exception as exc:
+            print(f"{str(level or 'default'):<16} REJECTED, {str(exc)[:150]}")
+            continue
+        avg = {k: sum(r[k] for r in rows) / len(rows) for k in rows[0]}
+        if level is None:
+            baseline = avg["cost"]
+        delta = ""
+        if baseline and level is not None:
+            delta = f"{(baseline - avg['cost']) / baseline * 100:+.1f}%"
+        print(f"{str(level or 'default'):<16}{avg['visible']:>9.0f}{avg['thought']:>9.0f}"
+              f"{avg['billed']:>9.0f}{avg['cost']:>12.6f}{delta:>13}")
+
+    print()
+    print("positive percent means cheaper than leaving thinking_level unset")
+
+
+if __name__ == "__main__":
+    main()

--- a/gemini-token-cost/skill/SKILL.md
+++ b/gemini-token-cost/skill/SKILL.md
@@ -20,8 +20,8 @@ larger than the visible answer.
 > Billed output equals `usage.total_output_tokens` plus `usage.total_thought_tokens`. The pricing
 > page states the output price is "including thinking tokens". `usage.total_tokens` is input plus
 > output plus thought, so it is not a drop in replacement either. Measured 2026-07-21, a single
-> short answer call returned `total_input_tokens` 12, `total_output_tokens` 281,
-> `total_thought_tokens` 596, `total_tokens` 889.
+> short answer call returned `total_input_tokens` 12, `total_output_tokens` 323,
+> `total_thought_tokens` 647, `total_tokens` 982.
 
 > [!IMPORTANT]
 > Use `google-genai>=2.3.0`, verified on 2.12.1. The client surface is

--- a/gemini-token-cost/skill/SKILL.md
+++ b/gemini-token-cost/skill/SKILL.md
@@ -104,7 +104,9 @@ client.interactions.create(
 )
 ```
 
-Measured 2026-07-21, `gemini-3.6-flash`, long context short answer, 3 samples per level.
+Measured 2026-07-21, `gemini-3.6-flash`, 3 samples per level.
+
+Long context, short answer.
 
 | thinking_level | thought tokens | cost USD | vs unset |
 | --- | --- | --- | --- |
@@ -112,10 +114,24 @@ Measured 2026-07-21, `gemini-3.6-flash`, long context short answer, 3 samples pe
 | `low` | 526 | 0.006342 | 29.4 percent cheaper |
 | `high` | 928 | 0.009309 | 3.6 percent more expensive |
 
+Long answer.
+
+| thinking_level | visible | thought tokens | cost USD | vs unset |
+| --- | --- | --- | --- | --- |
+| unset | 3563 | 1467 | 0.037810 | |
+| `low` | 2866 | 0 | 0.021583 | 42.9 percent cheaper |
+| `high` | 3484 | 1523 | 0.037638 | 0.5 percent cheaper |
+
 > [!IMPORTANT]
-> Stacking both levers beats either alone. `gemini-3.5-flash` unset costs 0.013534 on that
-> workload, `gemini-3.6-flash` with `thinking_level: "low"` costs 0.006342, a **53 percent**
-> reduction. Roughly half of that comes from the model and half from the knob.
+> `low` is adaptive, not a fixed token budget. It drove thinking to **zero** on the long answer
+> workload while still spending 526 thought tokens on the long context one. Do not assume a level
+> maps to a fixed cost, measure it per workload.
+
+> [!IMPORTANT]
+> Stacking both levers beats either alone, and both shapes land in the same place. Long context,
+> `gemini-3.5-flash` unset 0.013534 to `gemini-3.6-flash` at `low` 0.006342, a **53 percent**
+> reduction. Long answer, 0.049391 to 0.021583, a **56 percent** reduction. Roughly half of that
+> comes from the model and half from the knob.
 
 > [!WARNING]
 > **The API advertises four levels and accepts two.** Send an invalid value and the schema error
@@ -126,9 +142,11 @@ Measured 2026-07-21, `gemini-3.6-flash`, long context short answer, 3 samples pe
 > Reproduced on both models 2026-07-21.
 
 > [!WARNING]
-> `low` is not free. It buys fewer reasoning tokens, which on a task that genuinely needs reasoning
-> can buy a worse answer. Measure quality on your own task before adopting it, the cost number
-> alone is not the decision.
+> `low` is not free, and the measurements show what you are buying. On the long answer workload it
+> removed reasoning entirely AND shortened the visible answer by about a fifth, 3563 tokens down to
+> 2866. On a summarisation job that is likely fine. On a task that genuinely needs reasoning it is
+> a quality regression you will not see in the cost number. Measure output quality on your own
+> task before adopting it.
 
 ---
 

--- a/gemini-token-cost/skill/SKILL.md
+++ b/gemini-token-cost/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-token-cost
-description: Use this skill when measuring, comparing, or projecting the real cost of a Gemini API prompt, choosing between Gemini models on price, or working out why a Gemini bill is higher than the visible output suggests. Covers the Interactions API usage object, the separate total_thought_tokens field, why billed output equals visible output plus thinking, per model pricing, and the deprecated temperature, top_p and top_k sampling parameters. SDK used, google-genai.
+description: Use this skill when measuring, comparing, or projecting the real cost of a Gemini API prompt, reducing a Gemini bill, choosing between Gemini models on price, tuning thinking_level, or working out why a Gemini bill is higher than the visible output suggests. Covers the Interactions API usage object, the separate total_thought_tokens field, why billed output equals visible output plus thinking, thinking_level low and high and the two levels the API advertises but rejects, per model pricing for 3.6 Flash and 3.5 Flash-Lite, and the deprecated temperature, top_p and top_k sampling parameters. SDK used, google-genai.
 ---
 
 # Gemini Token Cost Skill
@@ -35,7 +35,8 @@ larger than the visible answer.
 > [!WARNING]
 > `temperature`, `top_p` and `top_k` were deprecated in the 2026-07-21 changelog. They are not
 > merely discouraged, they no longer do anything. See the sampling section below for the exact
-> observable symptoms, this one is silent and will not raise.
+> observable symptoms, this one is silent and will not raise. Note this deprecation is NOT in the
+> launch blog post, it is a separate line in the API changelog dated 2026-07-21.
 
 ---
 
@@ -87,6 +88,47 @@ print(f"{cost:.6f} USD")
 > Only the output price moved in the 3.6 Flash release. Input stayed at 1.50 per million. That
 > matters less than it sounds, see the measured results below, on long context short answer work
 > the input was only about sixteen percent of the bill.
+
+---
+
+## thinking_level, the biggest cost lever
+
+Thinking dominates the bill on short answer work, and it is configurable. This is usually a larger
+saving than choosing a different model.
+
+```python
+client.interactions.create(
+    model="gemini-3.6-flash",
+    input=prompt,
+    generation_config={"thinking_level": "low"},
+)
+```
+
+Measured 2026-07-21, `gemini-3.6-flash`, long context short answer, 3 samples per level.
+
+| thinking_level | thought tokens | cost USD | vs unset |
+| --- | --- | --- | --- |
+| unset | 876 | 0.008982 | |
+| `low` | 526 | 0.006342 | 29.4 percent cheaper |
+| `high` | 928 | 0.009309 | 3.6 percent more expensive |
+
+> [!IMPORTANT]
+> Stacking both levers beats either alone. `gemini-3.5-flash` unset costs 0.013534 on that
+> workload, `gemini-3.6-flash` with `thinking_level: "low"` costs 0.006342, a **53 percent**
+> reduction. Roughly half of that comes from the model and half from the knob.
+
+> [!WARNING]
+> **The API advertises four levels and accepts two.** Send an invalid value and the schema error
+> reads `Supported values: 'minimal', 'low', 'medium', 'high'`. Send `minimal` or `medium` to
+> `gemini-3.6-flash` or `gemini-3.5-flash-lite` and you get HTTP 400 with a different message,
+> `'minimal' is not a supported thinking level for this model. Allowed values are: low, high.`
+> Two validation layers disagree. Use `low` or `high` only, and do not trust the advertised list.
+> Reproduced on both models 2026-07-21.
+
+> [!WARNING]
+> `low` is not free. It buys fewer reasoning tokens, which on a task that genuinely needs reasoning
+> can buy a worse answer. Measure quality on your own task before adopting it, the cost number
+> alone is not the decision.
 
 ---
 
@@ -146,8 +188,11 @@ comparing `gemini-3.5-flash` against `gemini-3.6-flash`.
    get an actual prompt from them rather than inventing a representative one.
 2. Run `scripts/tokencost.py` against that prompt with `--repeat 3` or higher, adding
    `--monthly-calls` when the user has a volume in mind.
-3. Report the measured per call cost, the cheapest model, and what share of the bill is thinking.
-   State the sample count, and never present a single run as a result.
+3. If thinking is a large share of billed output, rerun with `--thinking-level low` and compare.
+   That knob is usually a bigger saving than switching model, and the two stack.
+4. Report the measured per call cost, the cheapest configuration, and what share of the bill is
+   thinking. State the sample count, and never present a single run as a result. When recommending
+   `low`, say plainly that it trades reasoning for cost and needs a quality check.
 
 ---
 
@@ -170,6 +215,7 @@ python scripts/tokencost.py "Explain why database indexes slow down writes."
 python scripts/tokencost.py --file prompt.txt --repeat 5
 python scripts/tokencost.py --file prompt.txt --models gemini-3.6-flash gemini-3.5-flash-lite
 python scripts/tokencost.py --file prompt.txt --repeat 3 --monthly-calls 200000
+python scripts/tokencost.py --file prompt.txt --thinking-level low
 ```
 
 > [!IMPORTANT]

--- a/gemini-token-cost/skill/SKILL.md
+++ b/gemini-token-cost/skill/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: gemini-token-cost
+description: Use this skill when measuring, comparing, or projecting the real cost of a Gemini API prompt, choosing between Gemini models on price, or working out why a Gemini bill is higher than the visible output suggests. Covers the Interactions API usage object, the separate total_thought_tokens field, why billed output equals visible output plus thinking, per model pricing, and the deprecated temperature, top_p and top_k sampling parameters. SDK used, google-genai.
+---
+
+# Gemini Token Cost Skill
+
+## Overview
+
+The token count you would naturally reach for is not the one you are billed for. The Gemini
+Interactions API reports thinking tokens separately from output tokens, and Google bills thinking
+at the full output rate. On short answer workloads the thinking is routinely twenty to thirty times
+larger than the visible answer.
+
+- Read the right fields off `usage` so a cost estimate is not silently wrong
+- Compare models on real measured cost rather than on headline pricing
+- Project a monthly bill from a measured per call cost
+
+> [!IMPORTANT]
+> Billed output equals `usage.total_output_tokens` plus `usage.total_thought_tokens`. The pricing
+> page states the output price is "including thinking tokens". `usage.total_tokens` is input plus
+> output plus thought, so it is not a drop in replacement either. Measured 2026-07-21, a single
+> short answer call returned `total_input_tokens` 12, `total_output_tokens` 281,
+> `total_thought_tokens` 596, `total_tokens` 889.
+
+> [!IMPORTANT]
+> Use `google-genai>=2.3.0`, verified on 2.12.1. The client surface is
+> `client.interactions.create(...)` and the clean text accessor is `interaction.output_text`.
+
+> [!WARNING]
+> The legacy `google-generativeai` (Python) and `@google/generative-ai` (JavaScript) packages are
+> deprecated. Do not use them. `gemini-2.5-*` and `gemini-1.5-*` model IDs are legacy, substitute
+> `gemini-3.6-flash`.
+
+> [!WARNING]
+> `temperature`, `top_p` and `top_k` were deprecated in the 2026-07-21 changelog. They are not
+> merely discouraged, they no longer do anything. See the sampling section below for the exact
+> observable symptoms, this one is silent and will not raise.
+
+---
+
+## Quick Start
+
+Read the billed token counts off a single call.
+
+```python
+import os
+from google import genai
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+interaction = client.interactions.create(
+    model="gemini-3.6-flash",
+    input="Name three things worth checking before a livestream goes live.",
+)
+
+u = interaction.usage
+visible = u.total_output_tokens or 0
+thought = u.total_thought_tokens or 0
+billed_output = visible + thought
+
+print(interaction.output_text)
+print(f"input {u.total_input_tokens}, visible {visible}, thought {thought}")
+print(f"billed output {billed_output}")
+```
+
+> [!WARNING]
+> Do not bill against `total_output_tokens` alone. On a long context short answer call measured
+> 2026-07-21, visible output averaged 26 tokens and thinking averaged 833, so costing off the
+> visible field alone understated the output bill by more than thirty times.
+
+Turn tokens into money.
+
+```python
+PRICES = {                                     # USD per 1M tokens, verified 2026-07-21
+    "gemini-3.6-flash":      {"input": 1.50, "output": 7.50},
+    "gemini-3.5-flash":      {"input": 1.50, "output": 9.00},
+    "gemini-3.5-flash-lite": {"input": 0.30, "output": 2.50},
+}
+
+price = PRICES["gemini-3.6-flash"]
+cost = (u.total_input_tokens / 1e6) * price["input"] + (billed_output / 1e6) * price["output"]
+print(f"{cost:.6f} USD")
+```
+
+> [!IMPORTANT]
+> Only the output price moved in the 3.6 Flash release. Input stayed at 1.50 per million. That
+> matters less than it sounds, see the measured results below, on long context short answer work
+> the input was only about sixteen percent of the bill.
+
+---
+
+## Sampling parameters are now a silent no-op
+
+```python
+# raises TypeError from the SDK, loud and easy to catch
+client.interactions.create(model="gemini-3.6-flash", input=p, temperature=0.2)
+# TypeError: create() got unexpected keyword argument(s): temperature.
+#            Use extra_body=... to send additional request body fields.
+
+# accepted, validated, and then ignored
+client.interactions.create(
+    model="gemini-3.6-flash", input=p, generation_config={"temperature": 0.0}
+)
+```
+
+> [!WARNING]
+> Passing `temperature` inside `generation_config` raises nothing and warns nothing, and the value
+> is even range validated, `temperature: 999` returns HTTP 400 `invalid_request`. It still has no
+> effect on sampling. Observable symptom, `temperature: 0.0` on a high entropy prompt returned 6
+> distinct answers out of 6 runs, the same spread as `temperature: 2.0` and as sending no config at
+> all (measured 2026-07-21, `gemini-3.6-flash`). If code depends on `temperature: 0` for
+> reproducible output, that guarantee is gone and nothing in the response will tell you.
+
+---
+
+## Measured behaviour
+
+All figures measured 2026-07-21 on `google-genai==2.12.1`, Python 3.13.3, 3 samples per model,
+comparing `gemini-3.5-flash` against `gemini-3.6-flash`.
+
+| workload shape | visible output change | thinking change | cost change |
+| --- | --- | --- | --- |
+| long answer, 57 token input | 16.3 percent fewer | 5.7 percent fewer | 28.0 percent cheaper |
+| long context, short answer, 1433 token input | 26.7 percent fewer | 32.3 percent fewer | 36.6 percent cheaper |
+
+- Google's headline claim of 17 percent fewer output tokens reproduced closely on the long answer
+  shape, 16.3 percent measured.
+- Long context short answer work saved MORE, not less, despite the input price being unchanged.
+  Thinking dominates that bill, so a model that thinks less wins there.
+- 3.6 Flash does not always think less. On an unrelated explanation prompt it produced 791 visible
+  tokens against 3.5 Flash's 1050 while thinking MORE, 1115 against 926, and still came out 19.6
+  percent cheaper overall. Measure the workload, do not assume the direction.
+
+> [!WARNING]
+> Single samples are misleading here, thinking token counts swing hard run to run. Two individual
+> runs of the long answer comparison showed 43.6 and 48.4 percent cost savings, while the 3 sample
+> average of the same comparison was 28.0 percent. Default to at least 3 samples before drawing a
+> conclusion.
+
+---
+
+## Workflow
+
+1. Work out the shape of the user's real workload, long answer or long context short answer, and
+   get an actual prompt from them rather than inventing a representative one.
+2. Run `scripts/tokencost.py` against that prompt with `--repeat 3` or higher, adding
+   `--monthly-calls` when the user has a volume in mind.
+3. Report the measured per call cost, the cheapest model, and what share of the bill is thinking.
+   State the sample count, and never present a single run as a result.
+
+---
+
+## Supporting files
+
+```
+gemini-token-cost/skill/
+├── SKILL.md
+├── requirements.txt
+└── scripts/
+    └── tokencost.py
+```
+
+- [scripts/tokencost.py](scripts/tokencost.py), measures and compares the real cost of a prompt
+  across Gemini models, counting thinking as billed output.
+
+```bash
+export GEMINI_API_KEY=...
+python scripts/tokencost.py "Explain why database indexes slow down writes."
+python scripts/tokencost.py --file prompt.txt --repeat 5
+python scripts/tokencost.py --file prompt.txt --models gemini-3.6-flash gemini-3.5-flash-lite
+python scripts/tokencost.py --file prompt.txt --repeat 3 --monthly-calls 200000
+```
+
+> [!IMPORTANT]
+> The price table lives in `PRICES` at the top of the script, as data. When Google moves prices,
+> edit that table, it is the only place a rate appears.
+
+---
+
+## Dependencies and Prerequisites
+
+- `google-genai >= 2.3.0`, verified on 2.12.1. Install with `pip install -U google-genai`.
+- Python >= 3.10, verified on 3.13.3. The `client.interactions` surface is absent on `google-genai`
+  1.x, and pip will silently resolve to 1.x on an older interpreter, which looks exactly like the
+  feature never shipped.
+- `GEMINI_API_KEY` in the environment.
+
+---
+
+## Documentation Pages
+
+You MUST fetch the matching page below before writing code. These hosted docs are the source of
+truth for parameters, types, and edge cases, do not rely solely on the examples above.
+
+- https://ai.google.dev/gemini-api/docs/pricing
+- https://ai.google.dev/gemini-api/docs/changelog
+- https://ai.google.dev/gemini-api/docs/computer-use
+- https://github.com/google-gemini/gemini-skills/blob/main/skills/gemini-interactions-api/SKILL.md
+
+> [!WARNING]
+> Built in computer use is not new in the 3.6 Flash release, despite being listed in the
+> announcement. It shipped 2026-06-24 with Gemini 3.5 Flash, and the tool worked in
+> `gemini-3-pro-preview` and `gemini-3-flash-preview` from 2026-01-29. The computer use tool itself
+> is still marked Preview even though the models carrying it are GA.
+
+## From the episode
+
+Built live on the Friday stream, 2026-09-25. Video link to follow.

--- a/gemini-token-cost/skill/requirements.txt
+++ b/gemini-token-cost/skill/requirements.txt
@@ -1,0 +1,1 @@
+google-genai>=2.3.0

--- a/gemini-token-cost/skill/scripts/tokencost.py
+++ b/gemini-token-cost/skill/scripts/tokencost.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Measure what a prompt actually costs across Gemini models.
+
+Counts BILLED output tokens, which is visible output plus thinking tokens,
+because Google bills thinking at the output rate and the thinking is usually
+bigger than the answer.
+
+Examples
+  python tokencost.py "Summarise the risks in this plan"
+  python tokencost.py --file prompt.txt --repeat 5
+  python tokencost.py --file prompt.txt --models gemini-3.6-flash gemini-3.5-flash-lite
+"""
+import argparse
+import os
+import sys
+
+from google import genai
+
+# Published prices, USD per 1M tokens, standard paid tier.
+# Source, https://ai.google.dev/gemini-api/docs/pricing
+# Verified 2026-07-21. Update this table when Google moves prices.
+PRICES = {
+    "gemini-3.6-flash": {"input": 1.50, "output": 7.50},
+    "gemini-3.5-flash": {"input": 1.50, "output": 9.00},
+    "gemini-3.5-flash-lite": {"input": 0.30, "output": 2.50},
+}
+
+
+def measure(client, model, prompt):
+    interaction = client.interactions.create(model=model, input=prompt)
+    u = interaction.usage
+    visible = u.total_output_tokens or 0
+    thought = u.total_thought_tokens or 0
+    billed_output = visible + thought
+    price = PRICES[model]
+    cost = (
+        (u.total_input_tokens or 0) / 1e6 * price["input"]
+        + billed_output / 1e6 * price["output"]
+    )
+    return {
+        "input": u.total_input_tokens or 0,
+        "visible": visible,
+        "thought": thought,
+        "billed_output": billed_output,
+        "cost": cost,
+    }
+
+
+def mean(rows, key):
+    return sum(r[key] for r in rows) / len(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("prompt", nargs="?", help="the prompt text, or use --file")
+    ap.add_argument("--file", help="read the prompt from a file instead")
+    ap.add_argument("--models", nargs="+", default=["gemini-3.5-flash", "gemini-3.6-flash"],
+                    help=f"models to compare, known, {', '.join(PRICES)}")
+    ap.add_argument("--repeat", type=int, default=3,
+                    help="samples per model, default 3, thinking token counts vary a lot")
+    ap.add_argument("--monthly-calls", type=int,
+                    help="also project a monthly bill at this call volume")
+    args = ap.parse_args()
+
+    if args.file:
+        with open(args.file) as fh:
+            prompt = fh.read()
+    elif args.prompt:
+        prompt = args.prompt
+    else:
+        ap.error("give a prompt as an argument or use --file")
+
+    unknown = [m for m in args.models if m not in PRICES]
+    if unknown:
+        ap.error(f"no price on file for {', '.join(unknown)}, add it to PRICES first")
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        sys.exit("set GEMINI_API_KEY first")
+    client = genai.Client(api_key=api_key)
+
+    print(f"prompt, {len(prompt)} characters, {args.repeat} sample(s) per model")
+    print()
+    header = (f"{'model':<24}{'in':>8}{'visible':>10}{'thought':>10}"
+              f"{'billed out':>12}{'cost USD':>12}")
+    print(header)
+    print("-" * len(header))
+
+    summary = []
+    for model in args.models:
+        rows = [measure(client, model, prompt) for _ in range(args.repeat)]
+        for r in rows:
+            print(f"{model:<24}{r['input']:>8}{r['visible']:>10}{r['thought']:>10}"
+                  f"{r['billed_output']:>12}{r['cost']:>12.6f}")
+        avg = {k: mean(rows, k) for k in ("input", "visible", "thought", "billed_output", "cost")}
+        avg["model"] = model
+        summary.append(avg)
+        if args.repeat > 1:
+            print(f"{'  mean':<24}{avg['input']:>8.0f}{avg['visible']:>10.0f}"
+                  f"{avg['thought']:>10.0f}{avg['billed_output']:>12.0f}{avg['cost']:>12.6f}")
+            lo = min(r["cost"] for r in rows)
+            hi = max(r["cost"] for r in rows)
+            print(f"{'  cost range':<24}{lo:.6f} to {hi:.6f}")
+        print()
+
+    for s in summary:
+        share = (s["thought"] / s["billed_output"] * 100) if s["billed_output"] else 0
+        print(f"{s['model']}, thinking is {share:.0f} percent of billed output")
+    print()
+
+    cheapest = min(summary, key=lambda s: s["cost"])
+    print(f"cheapest, {cheapest['model']} at {cheapest['cost']:.6f} USD per call")
+    for s in summary:
+        if s["model"] != cheapest["model"] and s["cost"]:
+            delta = (s["cost"] - cheapest["cost"]) / s["cost"] * 100
+            print(f"  {delta:.1f} percent cheaper than {s['model']}")
+
+    if args.monthly_calls:
+        print()
+        print(f"projected at {args.monthly_calls:,} calls per month")
+        for s in summary:
+            print(f"  {s['model']:<24}{s['cost'] * args.monthly_calls:>12.2f} USD")
+
+    if args.repeat == 1:
+        print()
+        print("one sample per model, treat this as an anecdote, rerun with --repeat 3")
+
+
+if __name__ == "__main__":
+    main()

--- a/gemini-token-cost/skill/scripts/tokencost.py
+++ b/gemini-token-cost/skill/scripts/tokencost.py
@@ -9,6 +9,7 @@ Examples
   python tokencost.py "Summarise the risks in this plan"
   python tokencost.py --file prompt.txt --repeat 5
   python tokencost.py --file prompt.txt --models gemini-3.6-flash gemini-3.5-flash-lite
+  python tokencost.py --file prompt.txt --thinking-level low
 """
 import argparse
 import os
@@ -26,8 +27,9 @@ PRICES = {
 }
 
 
-def measure(client, model, prompt):
-    interaction = client.interactions.create(model=model, input=prompt)
+def measure(client, model, prompt, thinking_level=None):
+    cfg = {"generation_config": {"thinking_level": thinking_level}} if thinking_level else {}
+    interaction = client.interactions.create(model=model, input=prompt, **cfg)
     u = interaction.usage
     visible = u.total_output_tokens or 0
     thought = u.total_thought_tokens or 0
@@ -61,6 +63,9 @@ def main():
                     help="samples per model, default 3, thinking token counts vary a lot")
     ap.add_argument("--monthly-calls", type=int,
                     help="also project a monthly bill at this call volume")
+    ap.add_argument("--thinking-level", choices=["low", "high"],
+                    help="thinking_level to send, low is usually the biggest cost lever. "
+                         "The API advertises minimal and medium too but both are rejected")
     args = ap.parse_args()
 
     if args.file:
@@ -80,7 +85,8 @@ def main():
         sys.exit("set GEMINI_API_KEY first")
     client = genai.Client(api_key=api_key)
 
-    print(f"prompt, {len(prompt)} characters, {args.repeat} sample(s) per model")
+    level_note = f", thinking_level {args.thinking_level}" if args.thinking_level else ""
+    print(f"prompt, {len(prompt)} characters, {args.repeat} sample(s) per model{level_note}")
     print()
     header = (f"{'model':<24}{'in':>8}{'visible':>10}{'thought':>10}"
               f"{'billed out':>12}{'cost USD':>12}")
@@ -89,7 +95,13 @@ def main():
 
     summary = []
     for model in args.models:
-        rows = [measure(client, model, prompt) for _ in range(args.repeat)]
+        try:
+            rows = [measure(client, model, prompt, args.thinking_level)
+                    for _ in range(args.repeat)]
+        except Exception as exc:
+            print(f"{model:<24} FAILED, {str(exc)[:160]}")
+            print()
+            continue
         for r in rows:
             print(f"{model:<24}{r['input']:>8}{r['visible']:>10}{r['thought']:>10}"
                   f"{r['billed_output']:>12}{r['cost']:>12.6f}")
@@ -108,6 +120,9 @@ def main():
         share = (s["thought"] / s["billed_output"] * 100) if s["billed_output"] else 0
         print(f"{s['model']}, thinking is {share:.0f} percent of billed output")
     print()
+
+    if not summary:
+        sys.exit("every model failed, nothing to compare")
 
     cheapest = min(summary, key=lambda s: s["cost"])
     print(f"cheapest, {cheapest['model']} at {cheapest['cost']:.6f} USD per call")


### PR DESCRIPTION
The episode skill and demos for e12, plus a gitignore fix.

## What it is

`usage` reports thinking tokens separately from output tokens, and Google bills
thinking at the full output rate. Billed output is `total_output_tokens` plus
`total_thought_tokens`, so costing off the obvious field understates the bill.

The skill ships `tokencost.py`, a parameterized utility you point at your own
prompt, not a replay of the episode demo.

## Measured

All 2026-07-21, `google-genai==2.12.1`, Python 3.13.3, 3 samples per model.

| workload | visible output | thinking | cost |
| --- | --- | --- | --- |
| long answer | 16.3% fewer | 5.7% fewer | 28.0% cheaper |
| long context, short answer | 26.7% fewer | 32.3% fewer | 36.6% cheaper |

`thinking_level: "low"` takes another 29.4% (long context) to 42.9% (long
answer, where it drives thinking to zero). Stacked with the model switch that
is 53% and 56%, roughly half from Google and half from one line of config.

## Sharp edges documented

- `temperature`, `top_p`, `top_k` are accepted, range validated, and a
  behavioural no-op. `temperature: 0.0` gave 6 of 6 distinct answers.
- The API advertises four `thinking_level` values and accepts two. `minimal`
  and `medium` return 400 with "Allowed values are: low, high" on both models.
- `low` is adaptive, not a fixed budget, and it also shortened the visible
  answer by about a fifth on the long answer shape. That trade is documented.

## Also here

`.gitignore` now globs `.env*` instead of matching `.env` exactly. A file named
`.env copy` was sitting untracked in this public repo and any `git add -A`
would have committed real credentials. `.env.example` and `.env.sample` stay
trackable. Nothing was ever committed, so this is prevention not cleanup.